### PR TITLE
[#66][🎨Style] mypage/shoppinginfo 스타일 완성 및 mypage/userinfo 기본 스타일

### DIFF
--- a/src/app/mypage/shoppinginfo/page.tsx
+++ b/src/app/mypage/shoppinginfo/page.tsx
@@ -1,3 +1,8 @@
 export default function ShoppingInfo() {
-  return <section>쇼핑정보</section>;
+  return (
+    <section className="w-[1000px]">
+      {/* 1. 여백 공간 */}
+      <div className="h-[67px]"></div>
+    </section>
+  );
 }

--- a/src/app/mypage/shoppinginfo/page.tsx
+++ b/src/app/mypage/shoppinginfo/page.tsx
@@ -3,6 +3,21 @@ export default function ShoppingInfo() {
     <section className="w-[1000px]">
       {/* 1. 여백 공간 */}
       <div className="h-[67px]"></div>
+      {/* 2. 멤버쉽 박스 */}
+      <div className="flex h-[150px] items-center justify-between bg-[#222] text-white">
+        <div className="flex-1 py-[35px] pl-[40px]">
+          <p className="text-[18px] font-regular">Membership</p>
+          <p className="text-[45px] font-bold">Welcome</p>
+        </div>
+        <div className="w-[275px] py-[35px] pl-[40px]">
+          <p className="text-[18px] font-regular">사용가능쿠폰</p>
+          <p className="text-[45px] font-bold">1</p>
+        </div>
+        <div className="w-[275px] py-[35px] pl-[40px]">
+          <p className="text-[18px] font-regular">마일리지</p>
+          <p className="text-[45px] font-bold">924</p>
+        </div>
+      </div>
     </section>
   );
 }

--- a/src/app/mypage/shoppinginfo/page.tsx
+++ b/src/app/mypage/shoppinginfo/page.tsx
@@ -3,8 +3,9 @@ export default function ShoppingInfo() {
     <section className="w-[1000px]">
       {/* 1. 여백 공간 */}
       <div className="h-[67px]"></div>
+
       {/* 2. 멤버쉽 박스 */}
-      <div className="flex h-[150px] items-center justify-between bg-[#222] text-white">
+      <div className="mb-[65px] flex h-[150px] items-center justify-between bg-[#222] text-white">
         <div className="flex-1 py-[35px] pl-[40px]">
           <p className="text-[18px] font-regular">Membership</p>
           <p className="text-[45px] font-bold">Welcome</p>
@@ -17,6 +18,66 @@ export default function ShoppingInfo() {
           <p className="text-[18px] font-regular">마일리지</p>
           <p className="text-[45px] font-bold">924</p>
         </div>
+      </div>
+
+      {/* 3. 구매 내역 */}
+      <div className="mb-[66px]">
+        <table className="w-[100%]">
+          <caption className="h-[64px] border-b-[3px] border-black text-left text-[28px] font-bold">
+            구매 내역
+          </caption>
+          <tbody>
+            <tr className="h-[50px] border-b-[1px] border-black text-[18px] font-bold">
+              <th>주문일</th>
+              <th>상품정보</th>
+              <th>결제금액</th>
+              <th>리뷰</th>
+            </tr>
+            <tr className="h-[50px] border-b-[1px] border-black text-center text-[18px] font-medium">
+              <td>2023.11.26</td>
+              <td className="text-left">BYREDO 상탈 33 EDT</td>
+              <td>195,000 원</td>
+              <td className="">
+                <button type="button" className="h-[50px] w-[70px]">
+                  작성
+                </button>
+                <button type="button" className="h-[50px] w-[70px]">
+                  수정
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {/* 4. 판매 내역 */}
+      <div className="mb-[66px]">
+        <table className="w-[100%]">
+          <caption className="h-[64px] border-b-[3px] border-black text-left text-[28px] font-bold">
+            판매 내역
+          </caption>
+          <tbody>
+            <tr className="h-[50px] border-b-[1px] border-black text-[18px] font-bold">
+              <th>등록일</th>
+              <th>상품정보</th>
+              <th>결제금액</th>
+              <th>리뷰</th>
+            </tr>
+            <tr className="h-[50px] border-b-[1px] border-black text-center text-[18px] font-medium">
+              <td>2023.11.26</td>
+              <td className="text-left">BYREDO 상탈 33 EDT</td>
+              <td>195,000 원</td>
+              <td className="">
+                <button type="button" className="h-[50px] w-[70px]">
+                  작성
+                </button>
+                <button type="button" className="h-[50px] w-[70px]">
+                  수정
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </section>
   );

--- a/src/app/mypage/shoppinginfo/page.tsx
+++ b/src/app/mypage/shoppinginfo/page.tsx
@@ -37,11 +37,17 @@ export default function ShoppingInfo() {
               <td>2023.11.26</td>
               <td className="text-left">BYREDO 상탈 33 EDT</td>
               <td>195,000 원</td>
-              <td className="">
-                <button type="button" className="h-[50px] w-[70px]">
+              <td className="w-fit">
+                <button
+                  type="button"
+                  className="h-[50px] w-[70px] hover:bg-[#A0D1EF]"
+                >
                   작성
                 </button>
-                <button type="button" className="h-[50px] w-[70px]">
+                <button
+                  type="button"
+                  className="h-[50px] w-[70px] hover:bg-[#A0D1EF]"
+                >
                   수정
                 </button>
               </td>
@@ -68,10 +74,16 @@ export default function ShoppingInfo() {
               <td className="text-left">BYREDO 상탈 33 EDT</td>
               <td>195,000 원</td>
               <td className="">
-                <button type="button" className="h-[50px] w-[70px]">
+                <button
+                  type="button"
+                  className="h-[50px] w-[70px] hover:bg-[#A0D1EF]"
+                >
                   작성
                 </button>
-                <button type="button" className="h-[50px] w-[70px]">
+                <button
+                  type="button"
+                  className="h-[50px] w-[70px] hover:bg-[#A0D1EF]"
+                >
                   수정
                 </button>
               </td>

--- a/src/app/mypage/userinfo/page.tsx
+++ b/src/app/mypage/userinfo/page.tsx
@@ -1,3 +1,9 @@
 export default function UserInfo() {
-  return <section>회원정보</section>;
+  return (
+    <section className="w-[1000px]">
+      <div className="flex h-[70px] items-center border-b-[3px] border-[#222]">
+        <p className="text-[28px] font-bold">회원정보 수정</p>
+      </div>
+    </section>
+  );
 }

--- a/src/containers/Filter.tsx
+++ b/src/containers/Filter.tsx
@@ -1,6 +1,6 @@
 export default function Filter({ title, children }) {
   return (
-    <div className="w-[250px]">
+    <div className="mr-[20px] w-[250px]">
       <p className="h-[70px] cursor-default border-b-[3px] border-solid border-[#222] text-[36px] font-bold">
         {title}
       </p>

--- a/src/containers/Filter.tsx
+++ b/src/containers/Filter.tsx
@@ -1,7 +1,7 @@
 export default function Filter({ title, children }) {
   return (
     <div className="mr-[20px] w-[250px]">
-      <p className="h-[70px] cursor-default border-b-[3px] border-solid border-[#222] text-[36px] font-bold">
+      <p className="flex h-[70px] cursor-default items-center border-b-[3px] border-solid border-[#222] text-[36px] font-bold">
         {title}
       </p>
       {children}


### PR DESCRIPTION
## 스타일 설명

![image](https://github.com/likelion-lab15/essentia/assets/79128016/12fba353-2876-47da-86a8-62015f529959)

마이페이지의 네스팅된 라우터인 `/mypage/shoppinginfo`의 스타일을 완성했습니다. 크게 네 구역으로 나누어 스타일을 했습니다.

![image](https://github.com/likelion-lab15/essentia/assets/79128016/56a2c0bb-7731-4496-ac0b-c2770c0b4656)

마이페이지의 네스팅된 라우터인 `/mypage/userinfo`의 기본 스타일을 잡았습니다.

## 추가 코멘트

### 1. 디자인 시안과의 차이점

![image](https://github.com/likelion-lab15/essentia/assets/79128016/ef298f59-a6f2-4a1e-969f-4f7b31531c48)

![image](https://github.com/likelion-lab15/essentia/assets/79128016/0105ab89-16a0-4eec-b35c-3e0dbf40fc0d)

디자인 파일과 조금 다르게 나온 부분이 있습니다. 현재 `<table>`을 사용해서 마크업을 해서 자동으로 들어간 여백으로 보입니다.

### 2. 회원정보 수정 페이지

회원정보 수정 페이지는 재사용되는 컴포넌트가 많이 있어 추후에 작업을 할 계획입니다.

## 이슈 트래커

ref: #23, #66, #67