### PR TITLE
[#68][🎨Style] Input 공용 컴포넌트 레이아웃 스타일 완성

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+type TInputField = {
+  label: string;
+  id: string;
+  type: string;
+  placeholder: string;
+  errormessage: string;
+  invalid: boolean;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+export default function InputField({
+  label,
+  id,
+  type,
+  placeholder,
+  errormessage,
+  invalid,
+  onChange,
+}: TInputField) {
+  return (
+    <div className="flex h-[76px] w-[400px] flex-col justify-center border-b border-primary text-14">
+      <label
+        className="flex h-[38px] w-full items-center font-semibold"
+        htmlFor={id}
+      >
+        {label}
+      </label>
+      <input
+        className="h-[38px] w-full"
+        id={id}
+        type={type}
+        placeholder={placeholder}
+        aria-errormessage={errormessage}
+        aria-invalid={invalid}
+        onChange={onChange}
+      />
+    </div>
+  );
+}

--- a/src/components/_index.ts
+++ b/src/components/_index.ts
@@ -2,3 +2,4 @@ export { default as AddressModal } from "./AddressModal";
 export { default as FilterList } from "./FilterList";
 export { default as Header } from "./Header";
 export { default as ProductCard } from "./ProductCard";
+export { default as InputField } from "./Input";


### PR DESCRIPTION
## 스타일 설명

<img width="561" alt="스크린샷 2023-12-05 16 29 25" src="https://github.com/likelion-lab15/essentia/assets/96248861/5e87479d-6084-4d68-b689-6aa4c6a020f8">

`Input` 공용 컴포넌트를 만들었습니다.

## 추가코멘트 

Input에서 보여줘야하는 에러메세지를 함께 컴포넌트에 포함시킬지 고려중입니다.

## 이슈트래커

Ref: #68