### PR TITLE
[🛠Refactor] `MoreButton` 컴포넌트 `<Link>`로 수정

### DIFF
--- a/src/app/mypage/edituser/page.tsx
+++ b/src/app/mypage/edituser/page.tsx
@@ -1,4 +1,4 @@
-export default function User() {
+export default function EditUser() {
   return (
     <section className="w-[1000px]">
       <div className="flex h-[70px] items-center border-b-[3px] border-[#222]">

--- a/src/app/mypage/history/_components/MoreButton.tsx
+++ b/src/app/mypage/history/_components/MoreButton.tsx
@@ -1,18 +1,13 @@
-"use client";
+import Link from "next/link";
 
-import { useRouter } from "next/navigation";
-
-const MoreButton = ({ path }) => {
-  const router = useRouter();
-
+const MoreButton = ({ href }) => {
   return (
-    <button
-      onClick={() => router.push(`${path}`)}
-      type="button"
+    <Link
+      href={href}
       className="absolute bottom-[-40px] right-0 text-[14px] font-medium text-[#808080] hover:text-[#222]"
     >
       + 더보기
-    </button>
+    </Link>
   );
 };
 

--- a/src/app/mypage/history/page.tsx
+++ b/src/app/mypage/history/page.tsx
@@ -38,13 +38,13 @@ export default function History() {
       {/* 3. 구매 내역 */}
       <div className="relative">
         <BuyHistoryTable buyHistoryData={buySlicedHistoryData} />
-        <MoreButton path={"/mypage/history/buyhistory"} />
+        <MoreButton href={"/mypage/history/buyhistory"} />
       </div>
 
       {/* 4. 판매 내역 */}
       <div className="relative">
         <SellHistoryTable sellHistoryData={sellSlicedHistoryData} />
-        <MoreButton path={"/mypage/history/sellhistory"} />
+        <MoreButton href={"/mypage/history/sellhistory"} />
       </div>
     </section>
   );

--- a/src/components/FilterList.tsx
+++ b/src/components/FilterList.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 export default function FilterList({ list }) {
   const { title, data } = list;
 
@@ -8,12 +10,13 @@ export default function FilterList({ list }) {
       </p>
       <ul className="mb-[20px]">
         {data.map((item, index) => {
+          const { title, href } = item;
           return (
             <li
               key={index}
               className="flex h-[36px] cursor-pointer items-center px-[25px] font-medium text-[#808080] hover:bg-[#A0D1EF] hover:text-[#222]"
             >
-              {item}
+              <Link href={href}>{title}</Link>
             </li>
           );
         })}

--- a/src/constants/shoppingInfoList.ts
+++ b/src/constants/shoppingInfoList.ts
@@ -1,7 +1,28 @@
 /* 마이페이지 필터 목록 */
 const shoppingInfoList = {
   title: "쇼핑 정보",
-  data: ["전체보기", "구매내역", "판매내역", "관심상품", "리뷰"],
+  data: [
+    {
+      title: "전체보기",
+      href: "/mypage/history",
+    },
+    {
+      title: "구매내역",
+      href: "/mypage/history/buyhistory",
+    },
+    {
+      title: "판매내역",
+      href: "/mypage/history/sellhistory",
+    },
+    {
+      title: "관심상품",
+      href: "/mypage/history",
+    },
+    {
+      title: "리뷰",
+      href: "/mypage/history",
+    },
+  ],
 };
 
 export default shoppingInfoList;

--- a/src/constants/userInfoList.ts
+++ b/src/constants/userInfoList.ts
@@ -1,7 +1,12 @@
 /* 마이페이지 필터 목록 */
 const userInfoList = {
   title: "회원 정보",
-  data: ["회원정보 수정"],
+  data: [
+    {
+      title: "회원정보 수정",
+      href: "/mypage/edituser",
+    },
+  ],
 };
 
 export default userInfoList;


### PR DESCRIPTION
## 내용 설명

![image](https://github.com/likelion-lab15/essentia/assets/79128016/53fca58f-2739-4779-bafb-c1d67c973ab5)

`MoreButton` 컴포넌트은 본래 `<button>`에 `useRouter`가 사용되어 클릭할 경우, 사용자를 `/mypage/history/buyhistory` 혹은 `/mypage/history/sellhistory`로 이동시켜줍니다. 하지만 페이지 이동은 `<button>`이 아니라 `<a>`가 사용되는 게 적절하다고 판단해 `<button>` 태그를 빼고 `<Link>`로 교체해줬습니다.