### PR TITLE
[✨Feat] `refreshToken`으로 만료된 `accessToken` 업데이트

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from "react";
 import type { Metadata } from "next";
 import "./globals.css";
+import { Header } from "@/components/_index";
 
 export const metadata: Metadata = {
   title: "Essentia",
@@ -10,7 +11,10 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="kor">
-      <body>{children}</body>
+      <body>
+        <Header />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,3 @@
-import Header from "@/components/Header";
-
 export default function Home() {
-  return (
-    <main>
-      <Header />
-      이곳은 홈입니다
-    </main>
-  );
+  return <main>이곳은 홈입니다</main>;
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,27 @@
 "use client";
-import React from "react";
+import { useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { getAccessToken, fetchRefreshToken } from "@/utils/_index";
 
 export default function Header() {
+  useEffect(() => {
+    if (localStorage.getItem("user")) {
+      const accessToken = getAccessToken();
+      const expirationTime = JSON.parse(atob(accessToken.split(".")[1])).exp;
+      const currentTime = new Date().getTime();
+      if (expirationTime <= currentTime) {
+        fetchRefreshToken()
+          .then(() => {
+            console.log("Your Token was refreshed");
+          })
+          .catch((error) => {
+            console.log(error.message);
+          });
+      }
+    }
+  }, []);
+
   return (
     <header
       role="banner"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,16 +9,10 @@ export default function Header() {
     if (localStorage.getItem("user")) {
       const accessToken = getAccessToken();
       const expirationTime = JSON.parse(atob(accessToken.split(".")[1])).exp;
-      const currentTime = new Date().getTime();
-      if (expirationTime <= currentTime) {
-        fetchRefreshToken()
-          .then(() => {
-            console.log("Your Token was refreshed");
-          })
-          .catch((error) => {
-            console.log(error.message);
-          });
-      }
+      const currentTime = Math.floor(new Date().getTime() / 1000);
+
+      // 토큰 만료됐을 경우
+      if (currentTime >= expirationTime) fetchRefreshToken();
     }
   }, []);
 

--- a/src/utils/_index.ts
+++ b/src/utils/_index.ts
@@ -1,2 +1,4 @@
 export { default as cn } from "./cn";
+export { default as fetchRefreshToken } from "./fetchRefreshToken";
 export { default as getAccessToken } from "./getAccessToken";
+export { default as getRefreshToken } from "./getRefreshToken";

--- a/src/utils/fetchRefreshToken.ts
+++ b/src/utils/fetchRefreshToken.ts
@@ -2,18 +2,19 @@ import axios from "axios";
 import { getRefreshToken } from "./_index";
 
 export default async function fetchRefreshToken() {
-  const res = await axios.get("https://localhost/api/users/refresh", {
-    headers: {
-      Authorization: `Bearer ${getRefreshToken()}`,
-    },
-  });
-
-  const prevUserData = JSON.parse(localStorage.getItem("user"));
-
-  const updatedUserData = {
-    ...prevUserData,
-    accessToken: res.data.accessToken,
-  };
-
-  localStorage.setItem("user", JSON.stringify(updatedUserData));
+  await axios
+    .get("https://localhost/api/users/refresh", {
+      headers: {
+        Authorization: `Bearer ${getRefreshToken()}`,
+      },
+    })
+    .then((res) => {
+      const newToken = res.data.accessToken;
+      const userData = JSON.parse(localStorage.getItem("user"));
+      userData.token.accessToken = newToken;
+      localStorage.setItem("user", JSON.stringify(userData));
+    })
+    .catch((err) => {
+      console.log(err.message);
+    });
 }

--- a/src/utils/fetchRefreshToken.ts
+++ b/src/utils/fetchRefreshToken.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+import { getRefreshToken } from "./_index";
+
+export default async function fetchRefreshToken() {
+  const res = await axios.get("https://localhost/api/users/refresh", {
+    headers: {
+      Authorization: `Bearer ${getRefreshToken()}`,
+    },
+  });
+
+  const prevUserData = JSON.parse(localStorage.getItem("user"));
+
+  const updatedUserData = {
+    ...prevUserData,
+    accessToken: res.data.accessToken,
+  };
+
+  localStorage.setItem("user", JSON.stringify(updatedUserData));
+}

--- a/src/utils/getRefreshToken.ts
+++ b/src/utils/getRefreshToken.ts
@@ -1,0 +1,5 @@
+/* RefreshToken 받아오기 */
+
+export default function getRefreshToken() {
+  return JSON.parse(localStorage.getItem("user")).token.refreshToken;
+}


### PR DESCRIPTION
## 기능 설명

![image](https://github.com/likelion-lab15/essentia/assets/79128016/e5c7e50d-fd59-401c-9b66-bcd9c8cf0a40)

로컬스토리지에 담긴 `refreshToken`을 사용해 새로운 `accessToken`을 받아와 로컬스토리지를 업데이트 시켜주는 `fetchRefreshToken` 함수를 만들었습니다. `Header`에서 useEffect를 사용해 `accessToken`의 만료 시간을 비교해 `accessToken`이 만료된다면 `fetchRefreshToken`이 실행되게 했습니다.

## 이슈 트래커

ref: #84