### PR TITLE
[🚑119]  `FilterList`에 `onClick`이 추가됨으로 발생한 버그 해결

### DIFF
--- a/src/components/FilterList.tsx
+++ b/src/components/FilterList.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 
 type FilterListProps = {
@@ -26,7 +28,7 @@ export default function FilterList({ list, onClick }: FilterListProps) {
             <li
               key={index}
               className="flex h-[36px] cursor-pointer items-center px-[25px] font-medium text-[#808080] hover:bg-[#A0D1EF] hover:text-[#222]"
-              onClick={() => onClick(title)}
+              onClick={onClick}
             >
               <Link href={href}>{title}</Link>
             </li>


### PR DESCRIPTION
## PR 내용

`FilterList` 공용 컴포넌트는 본래 서버 컴포넌트로 만들어졌지만, `onClick`이 추가되면서 에러가 발생했다. 이를 해결하기 위해 `use client`를 상단에 추가해 클라이언트 컴포넌트로 변경했다.

또한, `onClick`은 그 특수성 때문에 옵셔널로 들어갔지만, 코드 내부에서는 옵셔널이 아니라 확정적으로 사용이 되고 있어, onClick을 사용하지 않는 페이지에서 버그가 발생하던 걸 해결했다.