### PR TITLE
[🛠Refactor] 상품 상세페이지 네비게이션 리팩토링

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,8 @@
 /** @type {import('next').NextConfig} */
-// const nextConfig = {};
-
-module.exports = {
+const nextConfig = {
   images: {
-    domains: ["localhost"], // 이미지를 불러올 URL을 추가합니다.
+    domains: ["localhost", "*"],
   },
 };
+
+module.exports = nextConfig;

--- a/src/app/product/_sections/ProductDetail.tsx
+++ b/src/app/product/_sections/ProductDetail.tsx
@@ -39,6 +39,7 @@ export default function ProductPlus() {
     setActiveIndex(null);
   };
 
+  // 해당 섹션으로 스크롤 이동
   const scrollToSection = (ref: React.RefObject<HTMLElement>) => {
     const headerHeight = 240;
     if (ref && ref.current) {
@@ -110,6 +111,17 @@ export default function ProductPlus() {
     setActiveIndex(index === activeIndex ? null : index);
   };
 
+  const navItems = [
+    { label: "상세정보", ref: detailInfoRef, section: "detailInfo" },
+    { label: "교환 및 반품안내", ref: returnInfoRef, section: "returnInfo" },
+    { label: `REVIEW (${countReviews})`, ref: reviewRef, section: "review" },
+    {
+      label: "추천 상품",
+      ref: recommendedProductsRef,
+      section: "recommendedProducts",
+    },
+  ];
+
   return (
     <>
       {/* 상세페이지 네비게이션  */}
@@ -118,48 +130,18 @@ export default function ProductPlus() {
         className="sticky top-[79px] z-10 flex h-[64px] w-full flex-row justify-center border-b border-t border-primary bg-white"
       >
         <ul className="flex h-[62px] w-[800px] flex-row justify-between text-16 font-semibold text-tertiary">
-          <li>
-            <button
-              onClick={() => scrollToSection(detailInfoRef)}
-              className={`flex h-[64px] w-[200px] items-center justify-center hover:text-primary ${
-                activeSection === "detailInfo" ? "font-bold text-primary" : ""
-              }`}
-            >
-              상세정보
-            </button>
-          </li>
-          <li>
-            <button
-              onClick={() => scrollToSection(returnInfoRef)}
-              className={`flex h-[64px] w-[200px] items-center justify-center hover:text-primary ${
-                activeSection === "returnInfo" ? "font-bold text-primary" : ""
-              }`}
-            >
-              교환 및 반품안내
-            </button>
-          </li>
-          <li>
-            <button
-              onClick={() => scrollToSection(reviewRef)}
-              className={`flex h-[64px] w-[200px] items-center justify-center hover:text-primary ${
-                activeSection === "review" ? "font-bold text-primary" : ""
-              }`}
-            >
-              REVIEW ({countReviews})
-            </button>
-          </li>
-          <li>
-            <button
-              onClick={() => scrollToSection(recommendedProductsRef)}
-              className={`flex h-[64px] w-[200px] items-center justify-center hover:text-primary ${
-                activeSection === "recommendedProducts"
-                  ? "font-bold text-primary"
-                  : ""
-              }`}
-            >
-              추천 상품
-            </button>
-          </li>
+          {navItems.map((item) => (
+            <li key={item.section}>
+              <button
+                onClick={() => scrollToSection(item.ref)}
+                className={`flex h-[64px] w-[200px] items-center justify-center hover:text-primary ${
+                  activeSection === item.section ? "font-bold text-primary" : ""
+                }`}
+              >
+                {item.label}
+              </button>
+            </li>
+          ))}
         </ul>
       </nav>
       {/* 상세 이미지 SECTION */}


### PR DESCRIPTION
## 리팩토링 내용
<img width="800" alt="image" src="https://github.com/likelion-lab15/essentia/assets/96248861/0aa226aa-4070-402e-a0cb-8c74d098590b">

<img width="1041" alt="image" src="https://github.com/likelion-lab15/essentia/assets/96248861/0dcb04c0-74cd-49ad-ace7-6347a30a293b">

- 기존 네비게이션에서 각각 버튼에 동일한 마크업과 스타일링을 4개를 중복해서 했던 것을 .map을 이용하여 가독성을 높혔습니다.


## 이슈트래커

resolve: #86 