### PR TITLE
[🛠Refactor] mainImages 백엔드 api 요구사항에 따라 수정

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,5 +1,4 @@
 "use client";
-import Header from "@/components/Header";
 import axios from "axios";
 import React, { useState, useEffect } from "react";
 
@@ -78,7 +77,14 @@ export default function Admin() {
       // 파일 업로드 함수 호출
       const uploadedPaths = await uploadFiles([file]);
       // mainImages 상태 업데이트
-      setProduct({ ...product, mainImages: uploadedPaths });
+      setProduct({
+        ...product,
+        mainImages: uploadedPaths.map((path) => ({
+          url: path,
+          fileName: file.name,
+          orgName: file.name,
+        })),
+      });
       // 미리보기 URL 생성 및 저장
       const previewUrl = URL.createObjectURL(file);
       setPreviewImage(previewUrl);
@@ -105,10 +111,10 @@ export default function Admin() {
 
       console.log("서버에서의 대답", product); // 서버로 보내기 전에 콘솔 확인 (디버깅)
 
-      // localStorage에서 인증 토큰(accessToken)을 가져와서 요청 헤더에 포함
-      const userDataString = localStorage.getItem("user");
+      // sessionStorage에서 인증 토큰(accessToken)을 가져와서 요청 헤더에 포함
+      const userDataString = sessionStorage.getItem("user");
       const accessToken = userDataString
-        ? JSON.parse(userDataString).token.accessToken
+        ? JSON.parse(userDataString).state.user.token.accessToken
         : null;
       // 서버에 상품 정보를 POST 요청
       const response = await axios.post(

--- a/src/app/sell/page.tsx
+++ b/src/app/sell/page.tsx
@@ -1,5 +1,4 @@
 "use client";
-import Header from "@/components/Header";
 import axios from "axios";
 import React, { useState, useEffect } from "react";
 
@@ -77,7 +76,14 @@ export default function Sell() {
       // 파일 업로드 함수 호출
       const uploadedPaths = await uploadFiles(files);
       // mainImages 상태 업데이트
-      setProduct({ ...product, mainImages: uploadedPaths });
+      setProduct({
+        ...product,
+        mainImages: uploadedPaths.map((path) => ({
+          url: path,
+          fileName: files.name,
+          orgName: files.name,
+        })),
+      });
       // 각 파일에 대한 미리보기 URL 생성
       const previewUrls = files.map((file) => URL.createObjectURL(file));
       // 미리보기 URL들을 상태에 저장
@@ -105,10 +111,10 @@ export default function Sell() {
 
       console.log("서버에서의 대답", product); // 서버로 보내기 전에 콘솔 확인 (디버깅)
 
-      // localStorage에서 인증 토큰(accessToken)을 가져와서 요청 헤더에 포함
-      const userDataString = localStorage.getItem("user");
+      // sessionStorage에서 인증 토큰(accessToken)을 가져와서 요청 헤더에 포함
+      const userDataString = sessionStorage.getItem("user");
       const accessToken = userDataString
-        ? JSON.parse(userDataString).token.accessToken
+        ? JSON.parse(userDataString).state.user.token.accessToken
         : null;
       // 서버에 상품 정보를 POST 요청
       const response = await axios.post(

--- a/src/components/FilterList.tsx
+++ b/src/components/FilterList.tsx
@@ -28,7 +28,7 @@ export default function FilterList({ list, onClick }: FilterListProps) {
             <li
               key={index}
               className="flex h-[36px] cursor-pointer items-center px-[25px] font-medium text-[#808080] hover:bg-[#A0D1EF] hover:text-[#222]"
-              onClick={onClick}
+              onClick={() => onClick && onClick(title)}
             >
               <Link href={href}>{title}</Link>
             </li>

--- a/src/components/FilterList.tsx
+++ b/src/components/FilterList.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 
-type FilterListProps = {
+type TFilterList = {
   list: {
     title: string;
     data: {
@@ -13,7 +13,7 @@ type FilterListProps = {
   onClick?: () => void;
 };
 
-export default function FilterList({ list, onClick }: FilterListProps) {
+export default function FilterList({ list, onClick }: TFilterList) {
   const { title, data } = list;
 
   return (
@@ -27,7 +27,7 @@ export default function FilterList({ list, onClick }: FilterListProps) {
           return (
             <li
               key={index}
-              className="flex h-[36px] cursor-pointer items-center px-[25px] font-medium text-[#808080] hover:bg-[#A0D1EF] hover:text-[#222]"
+              className="flex h-[36px] cursor-pointer items-center px-[25px] font-medium text-tertiary hover:bg-secondary hover:text-primary"
               onClick={() => onClick && onClick(title)}
             >
               <Link href={href}>{title}</Link>


### PR DESCRIPTION
### mainImages 수정
<img width="1035" alt="image" src="https://github.com/likelion-lab15/essentia/assets/108773199/5ea95157-96a6-4149-a742-a57509afdf3b">

- mainImages 배열 수정했습니다. 

### FilterList 컴포넌트 수정 
<img width="1035" alt="image" src="https://github.com/likelion-lab15/essentia/assets/108773199/9f43e78a-f3a8-4876-93ad-dae8165ddead">

- onClick() 함수 호출 부분 앞에 onClick &&를 추가하여, onClick 함수가 정의되어 있을 때만 onClick(title)이 호출되도록 했습니다. 
- onClick prop이 전달되지 않은 경우에도 FilterList 컴포넌트가 에러 없이 작동할 것입니다.
- FilterList 타입이름 및 tailwind.config.ts 파일에 있는 컬러 스타일 수정했습니다. 