### PR TITLE
[🛠Refactor] 토큰 데이터 보관을 위한 `useTokenStore` 생성 

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -4,15 +4,15 @@ import axios from "axios";
 
 const BASE_URL = "https://localhost/api/";
 
-const user =
+const token =
   typeof window !== "undefined"
-    ? JSON.parse(sessionStorage.getItem("user")).state.user
+    ? JSON.parse(sessionStorage.getItem("token")).state.token
     : null;
 
 let accessToken;
 
-if (user) {
-  accessToken = user.token.accessToken;
+if (token) {
+  accessToken = token.accessToken;
 } else {
   accessToken = "";
 }

--- a/src/app/signin/_functions/postUserSignin.ts
+++ b/src/app/signin/_functions/postUserSignin.ts
@@ -15,7 +15,10 @@ export default async function postUserSignin({
       password: password,
     });
 
-    return res.data.item;
+    // user 정보와 token 정보를 분리
+    const { token, ...user } = res.data.item;
+
+    return { token, user };
   } catch (err) {
     if (err instanceof Error) {
       console.log(err.message);

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { postUserSignin } from "./_functions/_index";
-import { useUserStore } from "@/stores/useUserStore";
+import { useUserStore, useTokenStore } from "@/stores/_index";
 
 // 프로젝트 내부 임포트
 import { cn } from "@/utils/_index";
@@ -18,6 +18,7 @@ export default function SignIn() {
 
   /* 전역상태 */
   const setUser = useUserStore((state) => state.setUser);
+  const setToken = useTokenStore((state) => state.setToken);
 
   /* 훅 */
   const router = useRouter();
@@ -33,7 +34,8 @@ export default function SignIn() {
     const data = await postUserSignin({ email, password });
 
     if (data) {
-      setUser(data);
+      setUser(data.user);
+      setToken(data.token);
       setMessage(false);
       alert("로그인에 성공했습니다!");
       router.push("/");

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,21 +3,21 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useUserStore } from "@/stores/useUserStore";
+import { useTokenStore } from "@/stores/_index";
 import useTokens from "@/hooks/useTokens";
 
 export default function Header() {
   /* user 토큰을 위한 상태 */
-  const user = useUserStore((state) => state.user);
+  const token = useTokenStore((state) => state.token);
   const { getNewAccessToken } = useTokens();
-  
-   /* 로고 효과를 위한 상태 */
+
+  /* 로고 효과를 위한 상태 */
   const [isHovered, setIsHovered] = useState(false);
   const router = useRouter();
 
   useEffect(() => {
-    if (user) {
-      const accessToken = user.token.accessToken;
+    if (token) {
+      const accessToken = token.accessToken;
       const expirationTime = JSON.parse(atob(accessToken.split(".")[1])).exp;
       const currentTime = Math.floor(new Date().getTime() / 1000);
 
@@ -31,7 +31,7 @@ export default function Header() {
     } else {
       console.log("현재 토큰이 없는 상태입니다");
     }
-  }, [user, getNewAccessToken]);
+  }, [token, getNewAccessToken]);
 
   return (
     <header

--- a/src/hooks/useTokens.ts
+++ b/src/hooks/useTokens.ts
@@ -1,21 +1,21 @@
 "use client";
 
 import { axiosPrivate } from "@/api/axios";
-import { useUserStore } from "@/stores/useUserStore";
+import { useTokenStore } from "@/stores/_index";
 
 export default function useTokens() {
-  const user = useUserStore((state) => state.user);
-  const setUser = useUserStore((state) => state.setUser);
+  const token = useTokenStore((state) => state.token);
+  const setToken = useTokenStore((state) => state.setToken);
 
   // accessToken 가져오기
   const getAccessToken = () => {
-    const accessToken = user.token.accessToken;
+    const accessToken = token.token.accessToken;
     return accessToken;
   };
 
   // refreshToken 가져오기
   const getRefreshToken = () => {
-    const refreshToken = user.token.refreshToken;
+    const refreshToken = token.token.refreshToken;
     return refreshToken;
   };
 
@@ -31,9 +31,9 @@ export default function useTokens() {
       });
 
       const newAccessToken = res.data.accessToken;
-      const newUser = user;
-      newUser.token.accessToken = newAccessToken;
-      setUser(newUser);
+      const newToken = token;
+      newToken.token.accessToken = newAccessToken;
+      setToken(newToken);
     } catch (err) {
       if (err instanceof Error) {
         console.log(err.message);

--- a/src/stores/_index.ts
+++ b/src/stores/_index.ts
@@ -1,1 +1,2 @@
+export { useTokenStore } from "./useTokenStore";
 export { useUserStore } from "./useUserStore";

--- a/src/stores/useTokenStore.ts
+++ b/src/stores/useTokenStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+export const useTokenStore = create()(
+  persist(
+    (set) => ({
+      token: null,
+      setToken: (tokenData) => set(() => ({ token: tokenData })),
+    }),
+    {
+      name: "token",
+      storage: createJSONStorage(() => sessionStorage),
+    }
+  )
+);


### PR DESCRIPTION
## 수정 내용

![ezgif com-speed](https://github.com/likelion-lab15/essentia/assets/79128016/4968de0c-f179-4a1c-8ba2-e8b1bb584c75)

로그인에 성공하면 사용자 데이터가 담긴 `user` 객체와 토큰 데이터가 담긴 `token` 객체를 반환받고, 이를 각각 `useUserStore`와 `useTokenStore`에 저장합니다. 이렇게 저장된 각 데이터는 세션스토리지에 나뉘어져서 저장되어 새로고침이 되어도 초기화되지 않습니다.

## 추가 코멘트

위 변동 사항에 대해 자세히 알고 싶으신 분은 (#102)를 참조하시기 바랍니다.

## 이슈 트래커

ref: #102

