### PR TITLE
[🐛Bug] `refreshToken` 반환 실패 버그 해결

### DIFF
--- a/src/app/mypage/_components/UserName.tsx
+++ b/src/app/mypage/_components/UserName.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useUserStore } from "@/stores/_index";
+
+export default function UserName() {
+  const user = useUserStore((state) => state.user);
+
+  return (
+    <>
+      <span className="text-[48px] font-bold">{user.name} </span>님 환영합니다
+    </>
+  );
+}

--- a/src/app/mypage/_components/UserName.tsx
+++ b/src/app/mypage/_components/UserName.tsx
@@ -1,13 +1,22 @@
 "use client";
 
-import { useUserStore } from "@/stores/_index";
+import { useState, useEffect } from "react";
 
 export default function UserName() {
-  const user = useUserStore((state) => state.user);
+  const [userName, setUserName] = useState("");
+
+  useEffect(() => {
+    const user = sessionStorage.getItem("user");
+
+    if (user) {
+      const userName = JSON.parse(user).state.user.name;
+      setUserName(userName);
+    }
+  }, []);
 
   return (
     <>
-      <span className="text-[48px] font-bold">{user.name} </span>님 환영합니다
+      <span className="text-[48px] font-bold">{userName} </span>님 환영합니다
     </>
   );
 }

--- a/src/app/mypage/_components/_index.ts
+++ b/src/app/mypage/_components/_index.ts
@@ -1,0 +1,1 @@
+export { default as UserName } from "./UserName";

--- a/src/app/mypage/history/page.tsx
+++ b/src/app/mypage/history/page.tsx
@@ -15,13 +15,11 @@ export default function History() {
 
   useEffect(() => {
     (async () => {
-      const buyData = await getHistoryData("https://localhost/api/orders");
+      const buyData = await getHistoryData("orders");
       const buySlicedData = buyData.slice(0, 5);
       setBuySlicedHistoryData(buySlicedData);
 
-      const sellData = await getHistoryData(
-        "https://localhost/api/seller/products"
-      );
+      const sellData = await getHistoryData("seller/products");
       const sellSlicedData = sellData.slice(0, 5);
       setSellSlicedHistoryData(sellSlicedData);
     })();

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 import { userInfoList, shoppingInfoList } from "@/constants/_index";
 import { FilterList } from "@/components/_index";
 import { Filter } from "@/containers/_index";
+import { UserName } from "./_components/_index";
 
 export default function layout({ children }: { children: ReactNode }) {
   return (
@@ -10,7 +11,8 @@ export default function layout({ children }: { children: ReactNode }) {
       {/* 상단 콘텐츠 */}
       <div className="relative mb-[62px] h-[300px] items-center border-b-[1px] border-black text-[32px]">
         <div className="absolute left-0 top-[50%]">
-          <span className="text-[48px] font-bold">현지수 </span>님 환영합니다
+          {/* 사용자 이름 */}
+          <UserName />
         </div>
       </div>
       {/* 하단 콘텐츠 */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useTokenStore } from "@/stores/_index";
-import useTokens from "@/hooks/useTokens";
+import { useTokens } from "@/hooks/_index";
 
 export default function Header() {
   /* user 토큰을 위한 상태 */
@@ -23,8 +23,9 @@ export default function Header() {
 
       // 토큰 만료됐을 경우
       if (currentTime >= expirationTime) {
-        const newAccessToken = getNewAccessToken();
-        console.log(newAccessToken);
+        (async () => {
+          const newAccessToken = await getNewAccessToken();
+        })();
       } else {
         console.log("토큰이 아직 멀쩡합니다!");
       }

--- a/src/hooks/useTokens.ts
+++ b/src/hooks/useTokens.ts
@@ -9,13 +9,13 @@ export default function useTokens() {
 
   // accessToken 가져오기
   const getAccessToken = () => {
-    const accessToken = token.token.accessToken;
+    const accessToken = token.accessToken;
     return accessToken;
   };
 
   // refreshToken 가져오기
   const getRefreshToken = () => {
-    const refreshToken = token.token.refreshToken;
+    const refreshToken = token.refreshToken;
     return refreshToken;
   };
 
@@ -32,8 +32,9 @@ export default function useTokens() {
 
       const newAccessToken = res.data.accessToken;
       const newToken = token;
-      newToken.token.accessToken = newAccessToken;
+      newToken.accessToken = newAccessToken;
       setToken(newToken);
+      console.log("토큰 업데이트 성공!");
     } catch (err) {
       if (err instanceof Error) {
         console.log(err.message);


### PR DESCRIPTION
## 버그 내용

로그인에 성공할 경우에 받는 `accessToken`이 만료되면 `Header` 컴포넌트의 useEffect에서 만료시간과 현재시간을 비교해 만료가 됐다면 `refreshToken`을 사용해 새로운 `accessToken`을 받아오는 기능이 동작하지 않는 걸 발견하고 수정했다.

## 상세 내용

### 1. Unresolved Promise 해결

![image](https://github.com/likelion-lab15/essentia/assets/79128016/49cefec9-299a-40e5-8bf0-d1600261e5bd)

`Header` 안의 useEffect에서 프로미스가 제대로 해결되지 않는 걸 발견하고, 즉시실행함수에 담아줬다.

### 2. undefined 해결

![image](https://github.com/likelion-lab15/essentia/assets/79128016/61a7bc4a-4f82-42f9-8aa2-d801e7ab38e5)

`refreshToken`에 접근하는 데이터가 `undefined`가 반환되는 걸 확인하고 속성값을 수정했다.