### PR TITLE
[🛠Refactor] 회원정보수정 페이지 타입 리팩토링

### DIFF
--- a/src/app/mypage/edituser/page.tsx
+++ b/src/app/mypage/edituser/page.tsx
@@ -1,34 +1,54 @@
 "use client";
 
-import { useState } from "react";
+import {
+  useState,
+  ChangeEvent,
+  Dispatch,
+  SetStateAction,
+  FormEvent,
+} from "react";
 import { Button, AddressModal } from "@/components/_index";
 import { useUserStore } from "@/stores/useUserStore";
 import { axiosPrivate } from "@/api/axios";
 import { cn } from "@/utils/_index";
 
 export default function EditUser() {
+  // user
   const user = useUserStore((state) => state.user);
   const setUser = useUserStore((state) => state.setUser);
 
-  const [name, setName] = useState(user?.name);
-  const [phone, setPhone] = useState(user?.phone);
+  // input.value
+  const [name, setName] = useState(user?.name || "");
+  const [phone, setPhone] = useState(user?.phone || "");
   const [oldPassword, setOldPassword] = useState("");
   const [newPassword, setNewPassowrd] = useState("");
-
-  const [birthday, setBirthday] = useState(user?.extra.birthday);
-  const [address, setAddress] = useState(user?.extra.addressBook.value);
+  const [birthday, setBirthday] = useState(user?.extra.birthday || "");
+  const [address, setAddress] = useState(user?.extra.addressBook.value || "");
   const [detailAddress, setDetailAddress] = useState(
-    user?.extra.addressBook.detail
+    user?.extra.addressBook.detail || ""
   );
 
-  // 경고 메세지 상태 관리
+  // warning
   const [message, setMessage] = useState(false);
 
-  // 주소 API 관련 상태 관리
+  // address
   const [isAddressModalOpen, setAddressModalOpen] = useState(false);
 
+  // input값 업데이트 기능
+  const handleInputValue =
+    (setter: Dispatch<SetStateAction<string>>) =>
+    (e: ChangeEvent<HTMLInputElement>) => {
+      setter(e.target.value);
+    };
+
+  // 주소 변경 기능
+  const handleAddressChange = (data: any) => {
+    setAddress(data.address);
+    setAddressModalOpen(false);
+  };
+
   // 회원정보 수정기능
-  const handleFormSubmit = async (e) => {
+  const handleFormSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     const newUser = {
@@ -45,11 +65,19 @@ export default function EditUser() {
     };
 
     try {
-      const res = await axiosPrivate.patch(`users/${user._id}`, newUser);
-      const res2 = await axiosPrivate.get(`users/${user._id}`);
+      // 1. PATCH로 유저 정보 업데이트
+      if (user) {
+        await axiosPrivate.patch(`users/${user._id}`, newUser);
+      }
 
-      setUser(res2.data.item);
-      setMessage(false);
+      // 2. GET으로 업데이트된 유저 정보 불러오기
+      if (user) {
+        const res = await axiosPrivate.get(`users/${user._id}`);
+        setUser(res.data.item);
+        setMessage(false);
+      }
+
+      console.log(user);
       alert("회원정보 수정을 성공했습니다!");
     } catch (err) {
       if (err instanceof Error) {
@@ -58,17 +86,6 @@ export default function EditUser() {
       setMessage(true);
       alert("회원정보 수정을 실패했습니다!");
     }
-  };
-
-  // input값 업데이트 기능
-  const handleInputValue = (setter) => (e) => {
-    setter(e.target.value);
-  };
-
-  // 주소 변경 기능
-  const handleAddressChange = (data) => {
-    setAddress(data.address);
-    setAddressModalOpen(false);
   };
 
   return (
@@ -102,7 +119,7 @@ export default function EditUser() {
                   "flex items-center": message,
                 })}
               >
-                아이디를 확인해주세요
+                이메일을 확인해주세요
               </div>
             </div>
 

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -1,15 +1,19 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 
-type TUserData = {
+type TState = {
   user: object;
 };
 
-export const useUserStore = create()(
+type TAction = {
+  setUser: (newUser: TState) => void;
+};
+
+export const useUserStore = create<TState & TAction>()(
   persist(
     (set) => ({
-      user: null,
-      setUser: (userData: TUserData) => set(() => ({ user: userData })),
+      user: {},
+      setUser: (newUser) => set(() => ({ user: newUser })),
     }),
     {
       name: "user",

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -4,7 +4,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 
 type TUser = {
-  id: number;
+  _id: number;
   name: string;
   email: string;
   phone: string;

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -1,19 +1,37 @@
+/* eslint-disable no-unused-vars */
+
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 
-type TState = {
-  user: object;
+type TUser = {
+  id: number;
+  name: string;
+  email: string;
+  phone: string;
+  address: string;
+  type: string;
+  createdAt: string;
+  updatedAt: string;
+  extra: {
+    birthday: string;
+    membershipClass: string;
+    addressBook: {
+      value: string;
+      detail: string;
+    };
+  };
 };
 
-type TAction = {
-  setUser: (newUser: TState) => void;
+type TuseUserStore = {
+  user: TUser | null;
+  setUser: (user: TUser | null) => void;
 };
 
-export const useUserStore = create<TState & TAction>()(
+export const useUserStore = create<TuseUserStore>()(
   persist(
     (set) => ({
-      user: {},
-      setUser: (newUser) => set(() => ({ user: newUser })),
+      user: null,
+      setUser: (user) => set({ user }),
     }),
     {
       name: "user",


### PR DESCRIPTION
## 리팩토링 내용

`edituser` 페이지의 타입을 설정해 타입스크립트 에러를 처리했습니다.

## 추가 코멘트

`edituser` 페이지에서 유효성 검증에 대한 로직은 아직 추가하지 않았습니다. 그 외에도 state 지옥을 벗어나기 위해 리팩토링 과정을 진행해야 할 것으로 보입니다.