### PR TITLE
[🛠Refactor] buy페이지에서 상품 목록 없을 때 마크업 추가, 헤더 라우터 수정

### DIFF
--- a/src/app/products/[_id]/buy/page.tsx
+++ b/src/app/products/[_id]/buy/page.tsx
@@ -23,8 +23,11 @@ type TItem = {
   };
 };
 
+type TlowestPrice = number | null;
+
 export default function Buy(props: TProductProps) {
   const [items, setItems] = useState<TItem[]>([]);
+  const [lowestPrice, setLowestPrice] = useState<TlowestPrice>(null);
   const { product } = useProductStore();
   const router = useRouter();
   const getId = props.params._id;
@@ -36,17 +39,16 @@ export default function Buy(props: TProductProps) {
   const searchParams = useSearchParams();
   const getAmount = searchParams.get("amount");
   let targetAmount = 0;
-  if (getAmount == "50ml") {
+  if (getAmount === "50ml") {
     targetAmount = 50;
   } else {
     targetAmount = 100;
   }
   const renderItems = items.filter(
-    (item) => item.extra?.amount == targetAmount
+    (item) => item.extra?.amount === targetAmount
   );
 
   useEffect(() => {
-    // API 호출 및 데이터 가져오기
     async function buyInfo() {
       try {
         console.log("buyInfo Id: ", getId);
@@ -62,7 +64,15 @@ export default function Buy(props: TProductProps) {
     }
 
     buyInfo();
-  }, [getId]);
+
+    const lowest = items
+      .filter((item) => item.extra?.amount === targetAmount)
+      .reduce((min, item) => {
+        return item.price < min ? item.price : min;
+      }, Number.POSITIVE_INFINITY);
+
+    setLowestPrice(lowest === Number.POSITIVE_INFINITY ? null : lowest);
+  }, [getId, items, targetAmount]);
 
   return (
     <div className="mb-[300px] flex flex-col items-center justify-center">
@@ -79,61 +89,70 @@ export default function Buy(props: TProductProps) {
             width={200}
             height={200}
             alt="상품 이미지"
-            className="border-2 border-primary bg-[#F4F4F4]"
-          ></img>
+            className="border-2 border-primary bg-product"
+          />
           {/* 상품 정보 */}
           <div className="ml-[40px] flex h-[200px] w-[500px] flex-col justify-between">
             <div>
               <p className="border-b-2 border-primary text-22 font-bold">
                 {getBrand}
               </p>
-              <p className=" text-30 font-medium">{getName}</p>
+              <p className="text-30 font-medium">{getName}</p>
             </div>
             <p className="flex flex-row text-22 font-medium">{getAmount}</p>
             <div className="flex flex-row justify-between">
               <div className="flex w-[200px] flex-row items-baseline justify-start text-tertiary">
-                <p className="mr-[10px] text-16 font-medium">발매가</p>
+                <p className="mr-[10px] text-16 font-semibold">발매가</p>
                 <p className="text-28 font-bold">
                   {getPrice.toLocaleString()}원
                 </p>
               </div>
               <div className="flex w-[200px] flex-row items-baseline justify-end">
-                <p className="mr-[10px] text-16 font-medium">최저가</p>
-                <p className="text-28 font-bold">120,000원</p>
+                <p className="mr-[10px] text-16 font-semibold text-accent">
+                  최저가
+                </p>
+                <p className="text-28 font-bold">
+                  {lowestPrice ? `${lowestPrice.toLocaleString()}원` : "- 원"}
+                </p>
               </div>
             </div>
           </div>
         </div>
-        {/* 판매등록된 상품 리스트 */}
-        <div className="mb-[25px] flex w-[800px] flex-row flex-wrap pl-[25px] pr-[25px] text-18">
-          {renderItems.map((item, index) => (
-            <div
-              key={index}
-              className="flex w-[800px] flex-row justify-between"
-            >
-              <div className="mb-[15px] flex h-[60px] w-[600px] border-b-2 border-t-2 border-primary bg-white text-primary hover:bg-secondary">
-                <p className="flex h-[60px] flex-1 items-center justify-center">
-                  남은용량 : {item.extra.restamount}ml
-                </p>
-                <p className="flex h-[60px] flex-1 items-center justify-center">
-                  판매금액 : {Number(item.price).toLocaleString()}원
-                </p>
-                <p className="flex h-[60px] flex-1 items-center justify-center">
-                  구매일자 : {item.extra.date}
-                </p>
+        <div className="mb-[25px] flex w-[800px] flex-row flex-wrap justify-center pl-[25px] pr-[25px] text-18">
+          {renderItems.length === 0 ? (
+            <p className="text-18 font-semibold">
+              현재 등록된 판매상품이 없습니다. 🥲
+            </p>
+          ) : (
+            renderItems.map((item, index) => (
+              <div
+                key={index}
+                className="flex w-[800px] flex-row justify-between"
+              >
+                <div className="mb-[15px] flex h-[60px] w-[600px] border-b-2 border-t-2 border-primary bg-white text-primary hover:bg-secondary">
+                  <p className="flex h-[60px] flex-1 items-center justify-center">
+                    남은용량 : {item.extra.restamount}ml
+                  </p>
+                  <p className="flex h-[60px] flex-1 items-center justify-center">
+                    판매금액 : {Number(item.price).toLocaleString()}원
+                  </p>
+                  <p className="flex h-[60px] flex-1 items-center justify-center">
+                    구매일자 : {item.extra.date}
+                  </p>
+                </div>
+                <Button
+                  className="mb-[15px] h-[60px] w-[120px] border-2 border-primary bg-secondary text-primary hover:bg-primary hover:text-secondary"
+                  label="구매하기"
+                  type="button"
+                  onClick={() =>
+                    router.push(
+                      `/products/${getId}/order?&perchaseItem=${item._id}&amount=${item.extra.restamount}&price=${item.price}`
+                    )
+                  }
+                />
               </div>
-              <Button
-                className="mb-[15px] h-[60px] w-[120px] border-2 border-primary bg-secondary text-primary hover:bg-primary hover:text-secondary"
-                label="구매하기"
-                type="button"
-                onClick={() =>
-                  router.push(
-                    `/products/${getId}/order?&perchaseItem=${item._id}&amount=${item.extra.restamount}&price=${item.price}`
-                  )
-                }
-              />
-            </div>
-          ))}
+            ))
+          )}
         </div>
         {/* 뒤로가기 버튼 */}
         <div className="flex h-[100px] w-[800px] items-center justify-center">

--- a/src/app/products/[_id]/buy/page.tsx
+++ b/src/app/products/[_id]/buy/page.tsx
@@ -111,19 +111,19 @@ export default function Buy(props: TProductProps) {
               key={index}
               className="flex w-[800px] flex-row justify-between"
             >
-              <div className="flex h-[60px] w-[600px] border-b-2 border-t-2 border-primary bg-white text-primary hover:bg-secondary">
+              <div className="mb-[15px] flex h-[60px] w-[600px] border-b-2 border-t-2 border-primary bg-white text-primary hover:bg-secondary">
                 <p className="flex h-[60px] flex-1 items-center justify-center">
                   남은용량 : {item.extra.restamount}ml
                 </p>
                 <p className="flex h-[60px] flex-1 items-center justify-center">
-                  판매금액 : {item.price.toLocaleString()}원
+                  판매금액 : {Number(item.price).toLocaleString()}원
                 </p>
                 <p className="flex h-[60px] flex-1 items-center justify-center">
                   구매일자 : {item.extra.date}
                 </p>
               </div>
               <Button
-                className="h-[60px] w-[120px] border-2 border-primary bg-secondary text-primary hover:bg-primary hover:text-secondary"
+                className="mb-[15px] h-[60px] w-[120px] border-2 border-primary bg-secondary text-primary hover:bg-primary hover:text-secondary"
                 label="구매하기"
                 type="button"
                 onClick={() =>

--- a/src/constants/naviList.ts
+++ b/src/constants/naviList.ts
@@ -1,11 +1,10 @@
 /* Header 네비게이션 목록 */
 const naviList = [
-  { href: "/about", text: "ABOUT" },
   { href: "/products", text: "SHOP" },
-  { href: "/product", text: "DETAIL" },
-  { href: "/contact", text: "WOMEN" },
-  { href: "/men", text: "MEN" },
-  { href: "/magazine", text: "MAGAZINE" },
+  { href: "/products", text: "WOMEN" },
+  { href: "/products", text: "MEN" },
+  { href: "/products", text: "MAGAZINE" },
+  { href: "/", text: "ABOUT" },
 ];
 
 export default naviList;


### PR DESCRIPTION
## 변경사항


## Header
<img width="1436" alt="스크린샷 2023-12-23 22 51 14" src="https://github.com/likelion-lab15/essentia/assets/96248861/83ee85d8-2c26-4f4b-a0be-46f1493595d2">
- 헤더의 SHOP 위치를 앞으로 옮기고 WOMEN, MEN 등 현재 사용하지 않는 라우터는 /products로 이동하도록 수정하였습니다.


## buy 페이지 - 상품 없을 때 

<img width="1220" alt="스크린샷 2023-12-23 22 51 41" src="https://github.com/likelion-lab15/essentia/assets/96248861/791871ef-e991-49d7-904a-91e97280e322">

## buy 페이지 - 상품 있을 때

<img width="1038" alt="스크린샷 2023-12-23 22 51 33" src="https://github.com/likelion-lab15/essentia/assets/96248861/863cdf98-81b7-4db3-a866-bafa479fc8fa">

- 상품이 없으면 없다는 문구가 나오도록 수정하였습니다.
- 상품이 없을 때 최저가를 - 로 표시하도록 수정하였습니다.
- 최저가 문구 색상이 변경되었습니다.


## 이슈 트래커
Ref : #118



