### PR TITLE
[🛠Refactor] Buy, Order 페이지를 서버 컴포넌트로 리팩토링

### DIFF
--- a/src/app/products/[_id]/_sections/_components/ButtonBox.tsx
+++ b/src/app/products/[_id]/_sections/_components/ButtonBox.tsx
@@ -30,32 +30,6 @@ const addWishList = async (id: string) => {
   }
 };
 
-// const checkWishList = async ({ queryKey }: QueryFunctionContext<string[]>) => {
-//   const id = queryKey[1];
-//   const { accessToken } = userTokens();
-//   try {
-//     const res = await fetch(
-//       `${process.env.NEXT_PUBLIC_API_SERVER}bookmarks/products/${id}`,
-//       {
-//         method: "GET",
-//         headers: {
-//           "Content-Type": "application/json",
-//           Authorization: `Bearer ${accessToken}`,
-//         },
-//         cache: "no-cache",
-//       }
-//     );
-
-//     if (!res.ok) {
-//       throw new Error("위시리스트 확인 통신 실패");
-//     }
-//     return res.json();
-//   } catch (error) {
-//     console.error("위시리스트 확인 중 오류:", error);
-//     throw error;
-//   }
-// };
-
 export default function ButtonBox({
   id,
   amount,
@@ -63,13 +37,6 @@ export default function ButtonBox({
   id: string;
   amount: number[];
 }) {
-  /* React-Query */
-  // const data = useQuery({
-  //   queryKey: ["wishList", id],
-  //   queryFn: checkWishList,
-  // });
-
-  // console.log(data.data);
   // 사이즈 드롭다운박스 제목 상태 관리
   const [selectedSize, setSelectedSize] = useState("사이즈를 선택해주세요");
   // 사이즈 드롭다운박스 리스트 상태 관리
@@ -92,7 +59,9 @@ export default function ButtonBox({
     if (selectedSize === "사이즈를 선택해주세요") {
       alert("사이즈를 선택해주세요.");
     } else {
-      router.push(`/products/${id}/buy/?&amount=${selectedSize}`);
+      // ml 문자열 제거
+      const sizeWithoutUnit = selectedSize.replace("ml", "").trim();
+      router.push(`/products/${id}/buy/?&amount=${sizeWithoutUnit}`);
     }
   };
 
@@ -102,7 +71,9 @@ export default function ButtonBox({
     if (selectedSize === "사이즈를 선택해주세요") {
       alert("사이즈를 선택해주세요.");
     } else {
-      router.push(`/products/${id}/sell/?&amount=${selectedSize}`);
+      // ml 문자열 제거
+      const sizeWithoutUnit = selectedSize.replace("ml", "").trim();
+      router.push(`/products/${id}/sell/?&amount=${sizeWithoutUnit}`);
     }
   };
 

--- a/src/app/products/[_id]/buy/_components/BackButton.tsx
+++ b/src/app/products/[_id]/buy/_components/BackButton.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import Button from "@/components/Button";
+import { useRouter } from "next/navigation";
+
+export default function BackButton() {
+  const router = useRouter();
+  return (
+    <Button label="뒤로가기" type="button" onClick={() => router.back()} />
+  );
+}

--- a/src/app/products/[_id]/buy/_components/BuyButton.tsx
+++ b/src/app/products/[_id]/buy/_components/BuyButton.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import Button from "@/components/Button";
+import { useRouter } from "next/navigation";
+
+export default function BuyButton({
+  productId,
+  buyProductId,
+}: {
+  productId: string;
+  buyProductId: number;
+}) {
+  const router = useRouter();
+  return (
+    <Button
+      className="mb-[15px] h-[60px] w-[120px] border-2 border-primary bg-secondary text-primary hover:bg-primary hover:text-secondary"
+      label="구매하기"
+      type="button"
+      onClick={() =>
+        router.push(
+          `/products/${productId}/order?&perchaseItem=${buyProductId}`
+        )
+      }
+    />
+  );
+}

--- a/src/app/products/[_id]/buy/_components/BuyButton.tsx
+++ b/src/app/products/[_id]/buy/_components/BuyButton.tsx
@@ -6,9 +6,11 @@ import { useRouter } from "next/navigation";
 export default function BuyButton({
   productId,
   buyProductId,
+  amount,
 }: {
   productId: string;
   buyProductId: number;
+  amount: number;
 }) {
   const router = useRouter();
   return (
@@ -18,7 +20,7 @@ export default function BuyButton({
       type="button"
       onClick={() =>
         router.push(
-          `/products/${productId}/order?&perchaseItem=${buyProductId}`
+          `/products/${productId}/order?&perchaseItem=${buyProductId}&amount=${amount}`
         )
       }
     />

--- a/src/app/products/[_id]/buy/page.tsx
+++ b/src/app/products/[_id]/buy/page.tsx
@@ -128,7 +128,11 @@ export default async function Buy({
                       구매일자 : {item.extra.date}
                     </p>
                   </div>
-                  <BuyButton productId={targetId} buyProductId={item._id} />
+                  <BuyButton
+                    productId={targetId}
+                    buyProductId={item._id}
+                    amount={targetAmount}
+                  />
                 </div>
               )
             )

--- a/src/app/products/[_id]/buy/page.tsx
+++ b/src/app/products/[_id]/buy/page.tsx
@@ -1,78 +1,50 @@
 /* eslint-disable @next/next/no-img-element */
-"use client";
 
-import { Button } from "@/components/_index";
-import { useSearchParams, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import { useProductStore } from "@/stores/useProductStore";
-import axios from "@/api/axios";
+import BuyButton from "./_components/BuyButton";
+import BackButton from "./_components/BackButton";
+import { Key } from "react";
 
-type TProductProps = {
-  params: {
-    _id: string;
-  };
-};
-
-type TItem = {
-  _id: number;
-  price: number;
-  extra: {
-    amount: number;
-    restamount: number;
-    date: string;
-  };
-};
-
-type TlowestPrice = number | null;
-
-export default function Buy(props: TProductProps) {
-  const [items, setItems] = useState<TItem[]>([]);
-  const [lowestPrice, setLowestPrice] = useState<TlowestPrice>(null);
-  const { product } = useProductStore();
-  const router = useRouter();
-  const getId = props.params._id;
-  const getBrand = product.brand;
-  const getName = product.name;
-  const getImage = product.image;
-  const getPriceOrigin = product.price;
-  const getPrice = getPriceOrigin.toLocaleString();
-  const searchParams = useSearchParams();
-  const getAmount = searchParams.get("amount");
-  let targetAmount = 0;
-  if (getAmount === "50ml") {
-    targetAmount = 50;
-  } else {
-    targetAmount = 100;
+/* 데이터 fetching */
+async function getData(id: string) {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_SERVER}products/${id}`
+  );
+  if (!res.ok) {
+    throw new Error("Failed to 상품 데이터 fetch");
   }
-  const renderItems = items.filter(
-    (item) => item.extra?.amount === targetAmount
+
+  return res.json();
+}
+
+export default async function Buy({
+  searchParams,
+  params,
+}: {
+  searchParams: { amount: string };
+  params: { _id: string };
+}) {
+  const targetId = params._id;
+  const targetAmount = Number(searchParams.amount);
+  const product = await getData(targetId);
+  const productData = {
+    name: product.item.name,
+    price: product.item.price,
+    brand: product.item.extra.brand,
+    amount: product.item.extra.amount,
+    content: product.item.content,
+    image: product.item.mainImages[0].path,
+  };
+  const targetProductsList = product.item.options.item;
+  const renderProduct = targetProductsList.filter(
+    (item: { extra: { amount: number } }) => item.extra?.amount === targetAmount
   );
 
-  useEffect(() => {
-    async function buyInfo() {
-      try {
-        console.log("buyInfo Id: ", getId);
-        const response = await axios.get(`/products/${getId}`);
-        const result = response.data.item.options.item;
-        console.log(`result`, result);
-        setItems(result);
-        return result;
-      } catch (error) {
-        console.error("axios Error 🥲", error);
-        return [];
-      }
-    }
-
-    buyInfo();
-
-    const lowest = items
-      .filter((item) => item.extra?.amount === targetAmount)
-      .reduce((min, item) => {
-        return item.price < min ? item.price : min;
-      }, Number.POSITIVE_INFINITY);
-
-    setLowestPrice(lowest === Number.POSITIVE_INFINITY ? null : lowest);
-  }, [getId, items, targetAmount]);
+  const lowestPrice = renderProduct.reduce(
+    (min: number, item: { price: number }) => {
+      return item.price < min ? item.price : min;
+    },
+    Number.POSITIVE_INFINITY
+  );
 
   return (
     <div className="mb-[300px] flex flex-col items-center justify-center">
@@ -85,7 +57,7 @@ export default function Buy(props: TProductProps) {
         <div className="mb-[25px] flex h-[300px] w-[800px] items-center justify-center border-b-2 border-primary">
           {/* 이미지 */}
           <img
-            src={`${process.env.NEXT_PUBLIC_API_SERVER}${getImage}`}
+            src={`${process.env.NEXT_PUBLIC_API_SERVER}${productData.image}`}
             width={200}
             height={200}
             alt="상품 이미지"
@@ -95,16 +67,18 @@ export default function Buy(props: TProductProps) {
           <div className="ml-[40px] flex h-[200px] w-[500px] flex-col justify-between">
             <div>
               <p className="border-b-2 border-primary text-22 font-bold">
-                {getBrand}
+                {productData.brand}
               </p>
-              <p className="text-30 font-medium">{getName}</p>
+              <p className="text-30 font-medium">{productData.name}</p>
             </div>
-            <p className="flex flex-row text-22 font-medium">{getAmount}</p>
+            <p className="flex flex-row text-22 font-medium">
+              {targetAmount}ml
+            </p>
             <div className="flex flex-row justify-between">
               <div className="flex w-[200px] flex-row items-baseline justify-start text-tertiary">
                 <p className="mr-[10px] text-16 font-semibold">발매가</p>
                 <p className="text-28 font-bold">
-                  {getPrice.toLocaleString()}원
+                  {productData.price.toLocaleString()}원
                 </p>
               </div>
               <div className="flex w-[200px] flex-row items-baseline justify-end">
@@ -112,55 +86,57 @@ export default function Buy(props: TProductProps) {
                   최저가
                 </p>
                 <p className="text-28 font-bold">
-                  {lowestPrice ? `${lowestPrice.toLocaleString()}원` : "- 원"}
+                  {(
+                    lowestPrice === Number.POSITIVE_INFINITY
+                      ? null
+                      : lowestPrice
+                  )
+                    ? `${lowestPrice.toLocaleString()}원`
+                    : "- 원"}
                 </p>
               </div>
             </div>
           </div>
         </div>
         <div className="mb-[25px] flex w-[800px] flex-row flex-wrap justify-center pl-[25px] pr-[25px] text-18">
-          {renderItems.length === 0 ? (
+          {renderProduct.length === 0 ? (
             <p className="text-18 font-semibold">
               현재 등록된 판매상품이 없습니다. 🥲
             </p>
           ) : (
-            renderItems.map((item, index) => (
-              <div
-                key={index}
-                className="flex w-[800px] flex-row justify-between"
-              >
-                <div className="mb-[15px] flex h-[60px] w-[600px] border-b-2 border-t-2 border-primary bg-white text-primary hover:bg-secondary">
-                  <p className="flex h-[60px] flex-1 items-center justify-center">
-                    남은용량 : {item.extra.restamount}ml
-                  </p>
-                  <p className="flex h-[60px] flex-1 items-center justify-center">
-                    판매금액 : {Number(item.price).toLocaleString()}원
-                  </p>
-                  <p className="flex h-[60px] flex-1 items-center justify-center">
-                    구매일자 : {item.extra.date}
-                  </p>
+            renderProduct.map(
+              (
+                item: {
+                  extra: { restamount: number; date: string };
+                  price: number;
+                  _id: number;
+                },
+                index: Key
+              ) => (
+                <div
+                  key={index}
+                  className="flex w-[800px] flex-row justify-between"
+                >
+                  <div className="mb-[15px] flex h-[60px] w-[600px] border-b-2 border-t-2 border-primary bg-white text-primary hover:bg-secondary">
+                    <p className="flex h-[60px] flex-1 items-center justify-center">
+                      남은용량 : {item.extra.restamount}ml
+                    </p>
+                    <p className="flex h-[60px] flex-1 items-center justify-center">
+                      판매금액 : {Number(item.price).toLocaleString()}원
+                    </p>
+                    <p className="flex h-[60px] flex-1 items-center justify-center">
+                      구매일자 : {item.extra.date}
+                    </p>
+                  </div>
+                  <BuyButton productId={targetId} buyProductId={item._id} />
                 </div>
-                <Button
-                  className="mb-[15px] h-[60px] w-[120px] border-2 border-primary bg-secondary text-primary hover:bg-primary hover:text-secondary"
-                  label="구매하기"
-                  type="button"
-                  onClick={() =>
-                    router.push(
-                      `/products/${getId}/order?&perchaseItem=${item._id}&amount=${item.extra.restamount}&price=${item.price}`
-                    )
-                  }
-                />
-              </div>
-            ))
+              )
+            )
           )}
         </div>
         {/* 뒤로가기 버튼 */}
         <div className="flex h-[100px] w-[800px] items-center justify-center">
-          <Button
-            label="뒤로가기"
-            type="button"
-            onClick={() => router.back()}
-          />
+          <BackButton />
         </div>
       </div>
     </div>

--- a/src/app/products/[_id]/order/_components/OrderButton.tsx
+++ b/src/app/products/[_id]/order/_components/OrderButton.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import Button from "@/components/Button";
+
+export default function OrderButton() {
+  return (
+    <Button
+      label="구매 결정하기"
+      type="button"
+      className="mt-[100px] w-[600px] font-bold"
+      onClick={() => console.log("구매하기 버튼 클릭")}
+    />
+  );
+}


### PR DESCRIPTION
## 기존 페이지의 문제점과 변경 목표

- 구매하기와 주문하기 페이지는 클라이언트 컴포넌트로 만들어져 렌더링이 늦게 보이는 문제가 있었습니다.
- 사용자가 선택한 상품 데이터의 일부는 axios로 통신하여 가져오고 일부는 Query String을 사용하여 가져오고 있었습니다.
- 위 두가지를 보완하여 전체 페이지를 서버 컴포넌트로 변경하고 일부만 클라이언트 컴포넌트로 만들어 렌더링 속도를 높혔습니다.
- 불필요한 통신을 fetch의 cache기능을 이용하여 조절하고, 필요한 데이터만 Query String으로 전달하도록 변경하였습니다.

### 변경된 페이지 로딩 속도
![구매하기 페이지 리팩토링](https://github.com/likelion-lab15/essentia/assets/96248861/a93dadc1-aad3-43ff-b6e8-785c4d339513)

## 변경사항
### 구매하기 페이지
<img width="558" alt="image" src="https://github.com/likelion-lab15/essentia/assets/96248861/5e0482dc-e031-44a4-9fcd-51a142822d84">

- product/[id]/buy 의 page.tsx는 서버 컴포넌트로 만들고 버튼을 컴포넌트로 분리했습니다.
-`BackButton.tsx`와 `BuyButton.tsx`를 클라이언트 컴포넌트로 만들어서 import하여 사용했습니다.

### 주문하기 페이지
<img width="587" alt="image" src="https://github.com/likelion-lab15/essentia/assets/96248861/34f98122-dc9d-44ae-980e-68b4af182a52">

- 구매 결정하기 버튼을 클라이언트 컴포넌트로 분리하였습니다.


## 추가 코멘트
- 주문하기 페이지에서는 NextAuth의 변경내용에 따라 유저 정보를 가져오고 제출 통신을 변경해야합니다.
- 주문하기 페이지의 체크박스는 공용 컴포넌트로 만들 예정입니다. 