### PR TITLE
[🛠Refactor] `NextAuth`를 도입한 유저 세션 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "next-auth": "^4.24.5",
         "react": "^18",
         "react-daum-postcode": "^3.1.3",
-        "react-dom": "^18",
-        "swiper": "^11.0.5"
+        "react-dom": "^18"
       },
       "devDependencies": {
         "@svgr/webpack": "^8.1.0",
@@ -7122,24 +7121,6 @@
       "dev": true,
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/swiper": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.0.5.tgz",
-      "integrity": "sha512-rhCwupqSyRnWrtNzWzemnBLMoyYuoDgGgspAm/8iBD3jCvAWycPLH4Z3TB0O5520DHLzMx94yUMH/B9Efpa48w==",
-      "funding": [
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
-        },
-        {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
-        }
-      ],
-      "engines": {
-        "node": ">= 4.7.0"
       }
     },
     "node_modules/tailwind-merge": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.18.0",
         "next": "14.0.3",
+        "next-auth": "^4.24.5",
         "react": "^18",
         "react-daum-postcode": "^3.1.3",
         "react-dom": "^18",
@@ -2057,7 +2058,6 @@
       "version": "7.23.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.4.tgz",
       "integrity": "sha512-2Yv65nlWnWlSpe3fXEyX5i7fx5kIKo4Qbcj+hMO0odwaneFjfXw5fdum+4yL20O0QiaHpia0cYQ9xpNMqrBwHg==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -2442,6 +2442,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.1.1.tgz",
+      "integrity": "sha512-dhPeilub1NuIG0X5Kvhh9lH4iW3ZsHlnzwgwbOlgwQ2wG1IqFzsgHqmKPk3WzsdWAeaxKJxgM0+W433RmN45GA==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -3576,6 +3584,14 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.35.1",
@@ -5414,6 +5430,14 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.4.tgz",
+      "integrity": "sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5600,7 +5624,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5763,6 +5786,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "4.24.5",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.5.tgz",
+      "integrity": "sha512-3RafV3XbfIKk6rF6GlLE4/KxjTcuMCifqrmD+98ejFq73SRoj2rmzoca8u764977lH/Q7jo6Xu6yM+Re1Mz/Og==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@panva/hkdf": "^1.0.2",
+        "cookie": "^0.5.0",
+        "jose": "^4.11.4",
+        "oauth": "^0.9.15",
+        "openid-client": "^5.4.0",
+        "preact": "^10.6.3",
+        "preact-render-to-string": "^5.1.19",
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "next": "^12.2.5 || ^13 || ^14",
+        "nodemailer": "^6.6.5",
+        "react": "^17.0.2 || ^18",
+        "react-dom": "^17.0.2 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -5808,6 +5858,11 @@
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
+    },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -5936,6 +5991,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oidc-token-hash": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
+      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5943,6 +6006,28 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.4.tgz",
+      "integrity": "sha512-T1h3B10BRPKfcObdBklX639tVz+xh34O7GjofqrqiAQdm7eHsQ00ih18x6wuJ/E6FxdtS2u3FmUGPDeEcMwzNA==",
+      "dependencies": {
+        "jose": "^4.15.4",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/optionator": {
@@ -6244,6 +6329,26 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/preact": {
+      "version": "10.19.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.19.3.tgz",
+      "integrity": "sha512-nHHTeFVBTHRGxJXKkKu5hT8C/YWBkPso4/Gad6xuj5dbptt9iF9NZr9pHbPhBrnT2klheu7mHTxTZ/LjwJiEiQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
+      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6339,6 +6444,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6485,8 +6595,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-      "dev": true
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -7392,6 +7501,14 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -7504,8 +7621,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -11,14 +11,15 @@
   "dependencies": {
     "@tanstack/react-query": "^5.18.0",
     "next": "14.0.3",
+    "next-auth": "^4.24.5",
     "react": "^18",
     "react-daum-postcode": "^3.1.3",
     "react-dom": "^18",
     "swiper": "^11.0.5"
   },
   "devDependencies": {
-    "@tanstack/react-query-devtools": "^5.18.0",
     "@svgr/webpack": "^8.1.0",
+    "@tanstack/react-query-devtools": "^5.18.0",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "next-auth": "^4.24.5",
     "react": "^18",
     "react-daum-postcode": "^3.1.3",
-    "react-dom": "^18",
-    "swiper": "^11.0.5"
+    "react-dom": "^18"
   },
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -35,6 +35,15 @@ export const authOptions = {
       },
     }),
   ],
+  callbacks: {
+    async jwt({ token, user }) {
+      return { ...token, ...user };
+    },
+    async session({ session, token }) {
+      session.user = token;
+      return session;
+    },
+  },
 };
 
 export const handler = NextAuth(authOptions);

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,9 @@
+import NextAuth from "next-auth";
+
+export const authOptions = {
+  providers: [],
+};
+
+export const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -35,6 +35,9 @@ export const authOptions = {
       },
     }),
   ],
+  pages: {
+    signIn: "/signin",
+  },
   callbacks: {
     async jwt({ token, user }) {
       return { ...token, ...user };

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -13,7 +13,26 @@ export const authOptions = {
           placeholder: "비밀번호",
         },
       },
-      async authorize(credentials) {},
+      async authorize(credentials) {
+        const res = await fetch("https://onyx-onyx.koyeb.app/api/users/login", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            email: credentials?.email,
+            password: credentials?.password,
+          }),
+        });
+
+        const user = await res.json();
+
+        if (user) {
+          return user;
+        } else {
+          return null;
+        }
+      },
     }),
   ],
 };

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,7 +1,21 @@
 import NextAuth from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
 
 export const authOptions = {
-  providers: [],
+  providers: [
+    CredentialsProvider({
+      name: "Credentials",
+      credentials: {
+        username: { label: "Email", type: "text", placeholder: "이메일" },
+        password: {
+          label: "Password",
+          type: "password",
+          placeholder: "비밀번호",
+        },
+      },
+      async authorize(credentials) {},
+    }),
+  ],
 };
 
 export const handler = NextAuth(authOptions);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { Header, Footer } from "@/components/_index";
 import RQProvider from "../components/RQProvider";
+import { NextAuthProvider } from "@/contexts/_index";
 
 export const metadata: Metadata = {
   title: "Essentia",
@@ -13,12 +14,14 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="kor">
       <body>
-        <RQProvider>
-          <Header />
-          {children}
-          <div id="portal"></div>
-          <Footer />
-        </RQProvider>
+        <NextAuthProvider>
+          <RQProvider>
+            <Header />
+            {children}
+            <div id="portal"></div>
+            <Footer />
+          </RQProvider>
+        </NextAuthProvider>
       </body>
     </html>
   );

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -3,9 +3,7 @@
 // 노드 모듈 / 외부 라이브러리 임포트
 import { ChangeEvent, FormEvent, useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { postUserSignin } from "./_functions/_index";
-import { useUserStore, useTokenStore } from "@/stores/_index";
+import { signIn } from "next-auth/react";
 
 // 프로젝트 내부 임포트
 import { cn } from "@/utils/_index";
@@ -16,13 +14,6 @@ export default function SignIn() {
   const [password, setPassword] = useState("");
   const [message, setMessage] = useState(false);
 
-  /* 전역상태 */
-  const setUser = useUserStore((state) => state.setUser);
-  const setToken = useTokenStore((state) => state.setToken);
-
-  /* 훅 */
-  const router = useRouter();
-
   /* 이벤트 핸들러 */
   const handleInputValue =
     (setter: any) => (e: ChangeEvent<HTMLInputElement>) => {
@@ -32,18 +23,20 @@ export default function SignIn() {
   const handleFormSubmit = async (e: FormEvent) => {
     e.preventDefault();
 
-    const data = await postUserSignin({ email, password });
+    await signIn("credentials", {
+      email: email,
+      password: password,
+      redirect: true,
+      callbackUrl: "http://localhost:3000",
+    });
 
-    if (data) {
-      setUser(data.user);
-      setToken(data.token);
-      setMessage(false);
-      alert("로그인에 성공했습니다!");
-      router.push("/");
-    } else {
-      setMessage(true);
-      alert("로그인에 실패했습니다!");
-    }
+    // if (data) {
+    //   setMessage(false);
+    //   alert("로그인에 성공했습니다!");
+    // } else {
+    //   setMessage(true);
+    //   alert("로그인에 실패했습니다!");
+    // }
   };
 
   return (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,8 +7,12 @@ import { useState, useEffect } from "react";
 import { useTokenStore, useUserStore } from "@/stores/_index";
 import naviList from "@/constants/naviList";
 import SearchBar from "./SearchBar";
+import { useSession } from "next-auth/react";
 
 export default function Header() {
+  const { data: session } = useSession();
+  console.log(session);
+
   /* User 토큰을 위한 상태 관리 */
   const token = useTokenStore((state) => state.token);
   const user = useUserStore((state) => state.user);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,40 +2,17 @@
 import Link from "next/link";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useTokens } from "@/hooks/_index";
-import { useState, useEffect } from "react";
-import { useTokenStore, useUserStore } from "@/stores/_index";
+import { useState } from "react";
 import naviList from "@/constants/naviList";
 import SearchBar from "./SearchBar";
-import { useSession } from "next-auth/react";
+import { useSession, signIn, signOut } from "next-auth/react";
 
 export default function Header() {
   const { data: session } = useSession();
-  console.log(session);
-
-  /* User 토큰을 위한 상태 관리 */
-  const token = useTokenStore((state) => state.token);
-  const user = useUserStore((state) => state.user);
-
-  /* 로그아웃을 위한 토큰 상태 관리 */
-  const setToken = useTokenStore((state) => state.setToken);
-  const setUser = useUserStore((state) => state.setUser);
-
-  /* 로그인 상태를 위한 상태 */
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-
-  /* 로그아웃 처리 함수 */
-  const handleLogout = () => {
-    setUser(null);
-    setToken(null);
-    alert("로그아웃 되었습니다");
-  };
 
   /* 로고 효과를 위한 상태 */
   const [isHovered, setIsHovered] = useState(false);
   const router = useRouter();
-
-  const { getNewAccessToken } = useTokens();
 
   /* 검색바 노출 */
   const [showSearchBar, setShowSearchBar] = useState(false);
@@ -43,34 +20,6 @@ export default function Header() {
   const handleCloseSearchBar = () => {
     setShowSearchBar(false);
   };
-
-  useEffect(() => {
-    if (token) {
-      const accessToken = token.accessToken;
-      const expirationTime = JSON.parse(atob(accessToken.split(".")[1])).exp;
-      const currentTime = Math.floor(new Date().getTime() / 1000);
-
-      // 토큰 만료됐을 경우
-      if (currentTime >= expirationTime) {
-        (async () => {
-          await getNewAccessToken();
-        })();
-      } else {
-        console.log("토큰이 아직 멀쩡합니다!");
-      }
-    } else {
-      console.log("현재 토큰이 없는 상태입니다");
-    }
-  }, [token, getNewAccessToken]);
-
-  /* 마운트될 때 로그인, 토큰 상태를 확인하고 아이콘 변경 */
-  useEffect(() => {
-    if (token && user) {
-      setIsLoggedIn(true);
-    } else {
-      setIsLoggedIn(false);
-    }
-  }, [token, user]);
 
   return (
     <header
@@ -125,11 +74,7 @@ export default function Header() {
           </button>
           <button
             aria-label="마이페이지로 이동하기"
-            onClick={
-              isLoggedIn
-                ? () => router.push("/mypage/history")
-                : () => router.push("/signin")
-            }
+            onClick={() => router.push("/mypage/history")}
             className="bg-center bg-no-repeat"
           >
             <Image
@@ -141,11 +86,11 @@ export default function Header() {
           </button>
           <button
             aria-label="로그인 또는 로그아웃하기"
-            onClick={isLoggedIn ? handleLogout : () => router.push("/signin")}
+            onClick={session ? () => signOut() : () => signIn()}
             className="bg-center bg-no-repeat"
           >
             <Image
-              src={isLoggedIn ? "/signout-icon.svg" : "/signin-icon.svg"}
+              src={session ? "/signout-icon.svg" : "/signin-icon.svg"}
               alt="로그인 로그아웃 아이콘"
               width={24}
               height={24}

--- a/src/contexts/NextAuthProvider/NextAuthProvider.tsx
+++ b/src/contexts/NextAuthProvider/NextAuthProvider.tsx
@@ -1,0 +1,3 @@
+"use client";
+import { SessionProvider } from "next-auth/react";
+export default SessionProvider;

--- a/src/contexts/_index.ts
+++ b/src/contexts/_index.ts
@@ -1,0 +1,1 @@
+export { default as NextAuthProvider } from "./NextAuthProvider/NextAuthProvider";

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,5 @@
+export { default } from "next-auth/middleware";
+
+export const config = {
+  matcher: ["/mypage/:path*"],
+};


### PR DESCRIPTION
## 리팩토링 설명

![image](https://github.com/likelion-lab15/essentia/assets/79128016/96a7acfe-ef1e-47cf-b5c8-59c104aae4a2)

기존에 로그인에 성공했을 경우, 토큰 데이터를 세션 스토리지에 담아 이를 활용해 사용자의 로그인 유무를 판단하게 구성이 되어있었다. 이는 보안상으로나 유지보수의 측면에서도 적절하지 않아보였다. 그래서 `NextAuth` 도입해 유저의 세션을 추적하고 관리하도록 했다.

이를 통하여, 이전에 비해 보다 간결하게 유저 세션을 추적하고, 프로텍티드 라우트를 구현해 로그인 상태에 따른 접근 유무 또한 처리할 수 있게 됐다.

## 상세 설명

### 1. `NextAuth` 라이브러리 설치 및 환경 설정

![image](https://github.com/likelion-lab15/essentia/assets/79128016/de22dd6d-87d2-4025-a0db-9fa0ce56db23)

![image](https://github.com/likelion-lab15/essentia/assets/79128016/7c8309e2-939a-4317-83b1-51900293e2ae)

`next-auth` 버전4를 설치한 다음, `api/auth/[...nextauth]/route.ts`에서 옵션값을 설정했다.

### 2. CSC에서 유저 세션 접근하기

![image](https://github.com/likelion-lab15/essentia/assets/79128016/cbe64be9-fa7f-48db-a37c-de2b34808621)

CSC에서는 `useSession` 훅을 사용해 유저 세션에 접근할 수 있다. 이때 주의할 점은 `useSession`은 우리한테 필요한 것 이외의 다른 데이터들도 포함하고 있기 때문에 `data`를 사용해야 한다는 것이다.

![image](https://github.com/likelion-lab15/essentia/assets/79128016/ca66b421-bd71-4c9b-bc59-56dc9d72dce2)

위 코드에서는 구조분해할당으로 `data`를 직관성을 위해 `session`이라는 이름으로 사용하도록 했다.

![image](https://github.com/likelion-lab15/essentia/assets/79128016/fd4ac795-3c69-484c-b8e6-3099cb7b75fb)

![image](https://github.com/likelion-lab15/essentia/assets/79128016/83fa5029-1470-4f65-b73d-c639b79097d4)

로그인 되어있지 않을 때는, `null`을 반환한다. 하지만 로그인에 성공하면 사용자 세션이 담긴 객체를 반환한다. 토큰값에 접근하고 싶다면 위 객체를 분석해 토큰값에 접근하면 된다.

### 3. SSC에서 유저 세션 접근하기

![image](https://github.com/likelion-lab15/essentia/assets/79128016/90990c6c-552e-4b24-9980-cde61d60fa16)

SSC에서는 `getServerSession` 함수를 사용해야 한다. `getServerSession`은 프로미스를 반환하기 때문에 `async&await` 문법을 사용해야하며, 인자로 `/api/auth/[...nextauth]/route.ts`에 만들어둔 `authOptions`를 불러와 전달해야 한다. 

### 4. `signIn`, `signOut` 함수로 로그인, 로그아웃 기능 구현

![image](https://github.com/likelion-lab15/essentia/assets/79128016/101664a1-9ebf-4fe9-a9ea-d645a51c9021)

![image](https://github.com/likelion-lab15/essentia/assets/79128016/0a4bfb67-c796-4b49-b240-8ee05c1cfb8f)

`NextAuth`에서 제공해주는 `signIn`, `signOut` 함수로 헤더에서 로그인, 로그아웃 기능을 구현했다. `signIn`을 클릭할 경우, 로그인이 안된 상태라면 로그인 페이지로 이동해주고, `signOut`을 클릭하면 유저 세션을 지워준다.

### 4. 미들웨어로 프로텍티드 라우트 기능 구현

![image](https://github.com/likelion-lab15/essentia/assets/79128016/0c965015-3f52-4a99-b997-9ec80ee1440e)

`/src` 경로에 `middleware.ts` 파일을 생성하고 안에 `config`를 설정해줬다. `matcher`에 등록된 라우트에 사용자가 접근하려고 할 경우, 세션을 확인하고 로그인이 안된 상태라면 로그인 페이지로 이동을 시켜준다.

## 추가 설명

- `AuthJS`를 도입하려고 했으나, 아직은 베타 버전이라는 점, 또한 자료가 다소 부족한 점을 고려해 `NextAuth`를 도입했다. 추후에 `AuthJS`가 공식 버전으로 배포된다면 그때 추가 작업이 진행될 것으로 보인다.
- 이메일, 비밀번호, 그리고 외부 API를 사용한 방식은 `NextAuth`에서 권장하는 유저 세션 관리 방법이 아니다. 그렇기 때문에 `NextAuth`에서 제공해주는 편의성과 보안의 이점을 100프로 활용하고 있다고 보기는 어렵다.

## 이슈 트래커

Ref: #208 
