### PR TITLE
[✨Feat] 브라우저에서 유저 세션에 접근할 수 있는 `useClientSession` 커스텀 훅 생성

### DIFF
--- a/src/hooks/_index.ts
+++ b/src/hooks/_index.ts
@@ -2,3 +2,4 @@ export { default as useOutsideClick } from "./useOutsideClick";
 export { default as useTokens } from "./useTokens";
 export { default as useModal } from "./useModal";
 export { default as useFormReducer } from "./useFormReducer";
+export { default as useClientSession } from "./useClientSession";

--- a/src/hooks/useClientSession.ts
+++ b/src/hooks/useClientSession.ts
@@ -1,0 +1,36 @@
+/* 개발자 - 김진우 */
+
+import { useSession } from "next-auth/react";
+
+export default function useClientSession() {
+  const { data: session } = useSession();
+
+  /* 유저 세션을 반환하는 함수 */
+  const userSession = () => {
+    if (session) {
+      return session.user.item;
+    } else {
+      return { message: "유저 세션이 없습니다" };
+    }
+  };
+
+  /* JWT AccessToken을 반환하는 함수 */
+  const accessToken = () => {
+    if (session) {
+      return session.user.item.token.accessToken;
+    } else {
+      return { message: "유저 세션이 없습니다" };
+    }
+  };
+
+  /* JWT RefreshToken을 반환하는 함수 */
+  const refreshToken = () => {
+    if (session) {
+      return session.user.item.token.refreshToken;
+    } else {
+      return { message: "유저 세션이 없습니다" };
+    }
+  };
+
+  return { userSession, accessToken, refreshToken };
+}


### PR DESCRIPTION
## 기능 설명

![image](https://github.com/likelion-lab15/essentia/assets/79128016/74a3fcaa-383d-4c27-9c74-a2e1a3748531)

클라이언트에서 유저 세션에 접근할 때는 사용할 수 있는 커스텀훅을 만들었다.

## 함수 설명

`useClientSession` 커스텀 훅은 크게 `getServerSession`와 비슷하게 동작하지만, 클라이언트에서 사용될 수 있는 훅이다.

### 1.  `getServerSession`과 `authOptions` 불러오기

![image](https://github.com/likelion-lab15/essentia/assets/79128016/e582a316-4779-450f-9d37-6c7991760ca6)

최상단에서는  `getServerSession`과 `authOptions`를 불러오고 있습니다. 이 두 함수를 불러옴으로써 서버에서 유저 세션에 접근할 수 있게 됩니다.

### 2.  유저 세션을 반환하는 `userSession` 함수

![image](https://github.com/likelion-lab15/essentia/assets/79128016/5341f71a-45b0-4b4d-bacc-ac32073a55e4)

`userSession`은 유저와 관련된 직접적인 정보만 담고 있는 객체를 바로 반환하도록 했습니다.

### 3.  `accessToken`을 반환하는 `accessToken` 함수

![image](https://github.com/likelion-lab15/essentia/assets/79128016/ed385e3a-4cef-4038-a7b2-a21fecab3ebb)

`accessToken` 함수는 유저 세션에서 토큰 객체에 접근해 `accessToken`의 값을 반환하도록 했습니다. 클라이언트에서 `accessToken`이 필요할 때는 이 함수를 사용하면 됩니다.

### 4.  `refreshToken`을 반환하는 `refreshToken` 함수

![image](https://github.com/likelion-lab15/essentia/assets/79128016/eb9ad48b-340a-4173-87e5-bdbef199b9a1)

`refreshToken` 함수는 유저 세션에서 토큰 객체에 접근해 `refreshToken`의 값을 반환하도록 했습니다. 클라이언트에서 
 `refreshToken`이 필요할 때는 이 함수를 사용하면 됩니다.

## 이슈 트래커

Ref: #211