### PR TITLE
[🛠Refactor] `History` 페이지 컴포넌트 리팩토링

### DIFF
--- a/src/app/mypage/history/_functions/getHistoryData.ts
+++ b/src/app/mypage/history/_functions/getHistoryData.ts
@@ -1,30 +1,37 @@
-import axios, { axiosPrivate } from "@/api/axios";
+import { getUserSession, getAccessToken } from "@/utils/getServerSession";
 
-export default async function getHistoryData(url: string) {
+/* 구매내역 불러오기 */
+export const getBuyHistory = async () => {
+  const accessToken = await getAccessToken();
   try {
-    const response = await axiosPrivate.get(url);
-    return response.data.item;
-  } catch (err) {
-    if (err instanceof Error) {
-      console.log(err.message);
-    }
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER}/orders`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    const data = await res.json();
+    return data.item;
+  } catch (error) {
+    console.error("message:", error);
   }
-}
+};
 
-export async function getHistoryData2(url: string, userId: number) {
+/* 판매내역 불러오기 */
+export const getSellHistory = async () => {
+  const user = await getUserSession();
+  const customParam = JSON.stringify({ "extra.depth": 2 });
+  const fullUrl = `products?custom=${encodeURIComponent(customParam)}`;
+
   try {
-    const customParam = JSON.stringify({ "extra.depth": 2 });
-    const fullUrl = `${url}?custom=${encodeURIComponent(customParam)}`;
-    const response = await axios.get(fullUrl);
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER}/${fullUrl}`);
+    const data = await res.json();
 
-    const mySellData = response.data.item.filter(
-      (item: any) => item.seller_id === userId
+    const filteredItem = data.item.filter(
+      (item: any) => item.seller_id === user._id
     );
-
-    return mySellData;
-  } catch (err) {
-    if (err instanceof Error) {
-      console.log(err.message);
-    }
+    return filteredItem;
+  } catch (error) {
+    console.error("message:", error);
   }
-}
+};

--- a/src/app/mypage/history/page.tsx
+++ b/src/app/mypage/history/page.tsx
@@ -1,35 +1,19 @@
-/* eslint-disable react-hooks/exhaustive-deps */
-"use client";
+/* 김진우 */
 
-import { useState, useEffect } from "react";
-import getHistoryData, { getHistoryData2 } from "./_functions/getHistoryData";
+import { getBuyHistory, getSellHistory } from "./_functions/getHistoryData";
 import {
   BuyHistoryTable,
   Membership,
   MoreButton,
   SellHistoryTable,
 } from "./_components/_index";
-import { useUserStore } from "@/stores/_index";
 
-export default function History() {
-  const [buySlicedHistoryData, setBuySlicedHistoryData] = useState([]);
-  const [sellSlicedHistoryData, setSellSlicedHistoryData] = useState([]);
-  const user = useUserStore((state) => state.user);
-
-  useEffect(() => {
-    (async () => {
-      const [buyData, sellData] = await Promise.all([
-        getHistoryData("orders"),
-        getHistoryData2("products", user!._id),
-      ]);
-
-      const buySlicedData = buyData.slice(0, 5);
-      setBuySlicedHistoryData(buySlicedData);
-
-      const sellSlicedData = sellData.slice(0, 5);
-      setSellSlicedHistoryData(sellSlicedData);
-    })();
-  }, []);
+export default async function History() {
+  /* 구매 내역, 판매 내역 불러오기 */
+  const [buyData, sellData] = await Promise.all([
+    getBuyHistory(),
+    getSellHistory(),
+  ]);
 
   return (
     <section className="w-[1000px]">
@@ -40,14 +24,14 @@ export default function History() {
       <Membership />
 
       {/* 3. 구매 내역 */}
-      <div className="relative">
-        <BuyHistoryTable buyHistoryData={buySlicedHistoryData} />
+      {/* <div className="relative">
+        <BuyHistoryTable buyHistoryData={buyData.slice(0, 5)} />
         <MoreButton href={"/mypage/history/buyhistory"} />
-      </div>
+      </div> */}
 
       {/* 4. 판매 내역 */}
       <div className="relative">
-        <SellHistoryTable sellHistoryData={sellSlicedHistoryData} />
+        <SellHistoryTable sellHistoryData={sellData.slice(0, 5)} />
         <MoreButton href={"/mypage/history/sellhistory"} />
       </div>
     </section>


### PR DESCRIPTION
## 리팩토링 내용

` History` 페이지 컴포넌트에서 리팩토링 작업을 수행했다.

## 상세 내용

### 1. `getBuyHistory`와 `getSellHistory` 함수 리팩토링

![image](https://github.com/likelion-lab15/essentia/assets/79128016/31329ace-0ab6-4458-b778-4633c5858392)

![image](https://github.com/likelion-lab15/essentia/assets/79128016/39ccf7b8-f1aa-4b2c-b541-57793e9a035b)

`axios`로 사용하던 코드를 `fetch`로 변환했다. 또한, `accessToken`을 `getAccessToken` 함수에서 불러와 사용했다.

### 2. `History` 페이지 코드 압축

![image](https://github.com/likelion-lab15/essentia/assets/79128016/82eb0921-bd8d-4de6-bbdd-da0fd2515e74)

클라이언트 컴포넌트에서 서버 컴포넌트로 변환하면서 로직 코드를 18줄에서 4줄로 줄였다.

### 추가 내용

`BuyHistoryTable` 내부에서 사용되는 코드에 문제가 생겨 해당 컴포넌트는 일시적으로 주석처리를 해뒀다.