### PR TITLE
[🛠Refactor] `BuyHistoryTable` 컴포넌트 리팩토링

### DIFF
--- a/src/app/mypage/history/_components/BuyHistoryTable.tsx
+++ b/src/app/mypage/history/_components/BuyHistoryTable.tsx
@@ -1,32 +1,5 @@
-"use client";
-
-import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
-import { useReviewStore } from "@/stores/_index";
-import { axiosPrivate } from "@/api/axios";
-
-type TReview = {
-  _id: number;
-  rating: number;
-  content: string;
-  extra: {
-    title: string;
-  };
-  createdAt: string;
-  product: {
-    _id: number;
-    image: {
-      path: string;
-      name: string;
-      originalname: string;
-    };
-    name: string;
-  };
-  user: {
-    _id: number;
-    name: string;
-  };
-};
+import { ReviewButton } from "./_index";
+import { getRepliesData } from "../_functions/_index";
 
 type TProduct = {
   _id: number;
@@ -74,51 +47,12 @@ type TBuyHistory = {
 
 type TBuyHistoryData = TBuyHistory[];
 
-const BuyHistoryTable = ({
+const BuyHistoryTable = async ({
   buyHistoryData,
 }: {
   buyHistoryData: TBuyHistoryData;
 }) => {
-  const setReview = useReviewStore((state) => state.setReview);
-
-  const [reviewdProducts, setReviewedProducts] = useState<number[]>([]);
-
-  const router = useRouter();
-
-  useEffect(() => {
-    // 리뷰된 상품의 목록들
-    (async () => {
-      try {
-        const res = await axiosPrivate.get("replies");
-        const repliesData = res.data.item;
-
-        const reviewdProductsData = repliesData.map((reply: TReview) => {
-          return reply.product._id;
-        });
-
-        setReviewedProducts(reviewdProductsData);
-      } catch (error) {
-        if (error instanceof Error) {
-          console.log(error.message);
-        }
-      }
-    })();
-  }, []);
-
-  const handleClick = (buyHistory: TBuyHistory, product: TProduct) => () => {
-    const { _id: orderId } = buyHistory;
-    const { _id: productId, name, image, extra } = product;
-
-    setReview({
-      order_id: orderId,
-      product_id: productId,
-      brand: extra.brand,
-      name: name,
-      image: image,
-    });
-
-    router.push("/review");
-  };
+  const repliesData = await getRepliesData();
 
   return (
     <table className="mb-[66px] w-[100%]">
@@ -149,23 +83,7 @@ const BuyHistoryTable = ({
                   {price.toLocaleString("ko-KR")} 원
                 </td>
                 <td className="w-[10%]">
-                  {reviewdProducts.includes(_id) ? (
-                    <button
-                      type="button"
-                      className="h-[50px] w-[70px] hover:bg-[#A0D1EF]"
-                      disabled
-                    >
-                      완료
-                    </button>
-                  ) : (
-                    <button
-                      type="button"
-                      className="h-[50px] w-[70px] hover:bg-[#A0D1EF]"
-                      onClick={handleClick(buyHistory, product)}
-                    >
-                      작성
-                    </button>
-                  )}
+                  <ReviewButton repliesData={repliesData} id={_id} />
                 </td>
               </tr>
             );

--- a/src/app/mypage/history/_components/BuyHistoryTable.tsx
+++ b/src/app/mypage/history/_components/BuyHistoryTable.tsx
@@ -145,7 +145,9 @@ const BuyHistoryTable = ({
               >
                 <td className="w-[10%]">{createdAt.split(" ")[0]}</td>
                 <td className="w-[30%] text-left">{name}</td>
-                <td className="w-[10%]">{price.toLocaleString("ko-KR")} 원</td>
+                <td className="w-[10%] pr-[30px] text-right">
+                  {price.toLocaleString("ko-KR")} 원
+                </td>
                 <td className="w-[10%]">
                   {reviewdProducts.includes(_id) ? (
                     <button

--- a/src/app/mypage/history/_components/ReviewButton.tsx
+++ b/src/app/mypage/history/_components/ReviewButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+export default function ReviewButton({
+  repliesData,
+  id,
+}: {
+  repliesData: number[];
+  id: number;
+}) {
+  const handleClick = () => {
+    console.log("클릭!");
+  };
+
+  /* const handleClick = (buyHistory: TBuyHistory, product: TProduct) => () => {
+    const { _id: orderId } = buyHistory;
+    const { _id: productId, name, image, extra } = product;
+
+    setReview({
+      order_id: orderId,
+      product_id: productId,
+      brand: extra.brand,
+      name: name,
+      image: image,
+    });
+
+    router.push("/review");
+  }; */
+
+  if (repliesData.includes(id)) {
+    return (
+      <button type="button" className="h-[50px] w-[70px]" disabled>
+        완료
+      </button>
+    );
+  } else {
+    return (
+      <button
+        type="button"
+        className="h-[50px] w-[70px] hover:bg-[#A0D1EF]"
+        onClick={() => handleClick()}
+      >
+        작성
+      </button>
+    );
+  }
+}

--- a/src/app/mypage/history/_components/SellHistoryTable.tsx
+++ b/src/app/mypage/history/_components/SellHistoryTable.tsx
@@ -84,7 +84,9 @@ const SellHistoryTable = ({
             >
               <td className="w-[10%]">{createdAt.split(" ")[0]}</td>
               <td className="w-[30%] text-left">{truncateName}</td>
-              <td className="w-[10%]">{price.toLocaleString("ko-KR")} 원</td>
+              <td className="w-[10%] pr-[30px] text-right">
+                {price.toLocaleString("ko-KR")} 원
+              </td>
               <td className="w-[10%]">
                 <button
                   type="button"

--- a/src/app/mypage/history/_components/_index.ts
+++ b/src/app/mypage/history/_components/_index.ts
@@ -1,4 +1,5 @@
 export { default as BuyHistoryTable } from "./BuyHistoryTable";
 export { default as Membership } from "./Membership";
 export { default as MoreButton } from "./MoreButton";
+export { default as ReviewButton } from "./ReviewButton";
 export { default as SellHistoryTable } from "./SellHistoryTable";

--- a/src/app/mypage/history/_functions/_index.ts
+++ b/src/app/mypage/history/_functions/_index.ts
@@ -1,0 +1,2 @@
+export { getBuyHistory, getSellHistory } from "./getHistoryData";
+export { getRepliesData } from "./getRepliesData";

--- a/src/app/mypage/history/_functions/getRepliesData.ts
+++ b/src/app/mypage/history/_functions/getRepliesData.ts
@@ -1,5 +1,11 @@
 import { getAccessToken } from "@/utils/getServerSession";
 
+type TReview = {
+  product: {
+    _id: number;
+  };
+};
+
 /* 리뷰 데이터 불러오기 */
 export const getRepliesData = async () => {
   const accessToken = await getAccessToken();

--- a/src/app/mypage/history/_functions/getRepliesData.ts
+++ b/src/app/mypage/history/_functions/getRepliesData.ts
@@ -1,0 +1,23 @@
+import { getAccessToken } from "@/utils/getServerSession";
+
+/* 리뷰 데이터 불러오기 */
+export const getRepliesData = async () => {
+  const accessToken = await getAccessToken();
+  try {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER}/replies`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    const data = await res.json();
+
+    const reviewdProducts = data.item.map((reply: TReview) => {
+      return reply.product._id;
+    });
+
+    return reviewdProducts;
+  } catch (error) {
+    console.error("message:", error);
+  }
+};

--- a/src/app/mypage/history/page.tsx
+++ b/src/app/mypage/history/page.tsx
@@ -1,6 +1,6 @@
 /* 김진우 */
 
-import { getBuyHistory, getSellHistory } from "./_functions/getHistoryData";
+import { getBuyHistory, getSellHistory } from "./_functions/_index";
 import {
   BuyHistoryTable,
   Membership,
@@ -24,10 +24,10 @@ export default async function History() {
       <Membership />
 
       {/* 3. 구매 내역 */}
-      {/* <div className="relative">
+      <div className="relative">
         <BuyHistoryTable buyHistoryData={buyData.slice(0, 5)} />
         <MoreButton href={"/mypage/history/buyhistory"} />
-      </div> */}
+      </div>
 
       {/* 4. 판매 내역 */}
       <div className="relative">


### PR DESCRIPTION
## 리팩토링 내용

![image](https://github.com/likelion-lab15/essentia/assets/79128016/1d906a66-8131-4165-b37d-8c7f78aa274d)

`BuyHistoryTable` 컴포넌트를 서버 컴포넌트로 변환했고, 그 과정에서 코드의 양을 많이 줄였습니다.

## 상세 내용

1. 서버 컴포넌트로 불리하면서 코드량을 줄이고, 함수를 분리해서 사용했습니다.
2. 가격 부분의 위치가 불규칙해 우측으로 통일시켰습니다.
3. 사용자와 상호 작용이 이뤄지는 부분만 별도로 클라이언트 컴포넌트로 만들어 나머지는 서버 컴포넌트로 유지되게끔 했습니다.

## 참고 내용

리뷰 작성 페이지로 이동하는 로직이 쥬스탕드로 관리되는 부분이 있어, 이 부분과 관련되 추가 작업이 있을 것으로 보입니다.
