### PR TITLE
[🐛Bug] 로그아웃 상태일 때, 반환값 변경

### DIFF
--- a/src/app/mypage/history/buyhistory/page.tsx
+++ b/src/app/mypage/history/buyhistory/page.tsx
@@ -1,19 +1,8 @@
-"use client";
-
-import { useEffect, useState } from "react";
+import { getBuyHistory } from "../_functions/_index";
 import { BuyHistoryTable } from "../_components/_index";
-import getHistoryData from "../_functions/getHistoryData";
 
-export default function BuyHistory() {
-  const [buyHistoryData, setBuyHistoryData] = useState([]);
-
-  useEffect(() => {
-    (async () => {
-      const data = await getHistoryData("orders");
-      setBuyHistoryData(data);
-    })();
-  }, []);
-
+export default async function BuyHistory() {
+  const buyHistoryData = await getBuyHistory();
   return (
     <section className="w-[1000px]">
       <div className="pt-[6px]">

--- a/src/app/mypage/history/sellhistory/page.tsx
+++ b/src/app/mypage/history/sellhistory/page.tsx
@@ -1,21 +1,8 @@
-/* eslint-disable react-hooks/exhaustive-deps */
-"use client";
-
-import { useEffect, useState } from "react";
+import { getSellHistory } from "../_functions/_index";
 import { SellHistoryTable } from "../_components/_index";
-import { getHistoryData2 } from "../_functions/getHistoryData";
-import { useUserStore } from "@/stores/_index";
 
-export default function SellHistory() {
-  const [sellHistoryData, setSellHistoryData] = useState([]);
-  const user = useUserStore((state) => state.user);
-
-  useEffect(() => {
-    (async () => {
-      const data = await getHistoryData2("/products", user!._id);
-      setSellHistoryData(data);
-    })();
-  }, []);
+export default async function SellHistory() {
+  const sellHistoryData = await getSellHistory();
 
   return (
     <section className="w-[1000px]">

--- a/src/hooks/useClientSession.ts
+++ b/src/hooks/useClientSession.ts
@@ -10,7 +10,7 @@ export default function useClientSession() {
     if (session) {
       return session.user.item;
     } else {
-      return { message: "유저 세션이 없습니다" };
+      return;
     }
   };
 
@@ -19,7 +19,7 @@ export default function useClientSession() {
     if (session) {
       return session.user.item.token.accessToken;
     } else {
-      return { message: "유저 세션이 없습니다" };
+      return;
     }
   };
 
@@ -28,7 +28,7 @@ export default function useClientSession() {
     if (session) {
       return session.user.item.token.refreshToken;
     } else {
-      return { message: "유저 세션이 없습니다" };
+      return;
     }
   };
 

--- a/src/utils/getServerSession.ts
+++ b/src/utils/getServerSession.ts
@@ -10,7 +10,7 @@ export const getUserSession = async () => {
   if (session) {
     return session.user.item;
   } else {
-    return { message: "세션 정보가 없습니다" };
+    return;
   }
 };
 
@@ -21,7 +21,7 @@ export const getAccessToken = async () => {
   if (session) {
     return session.user.item.token.accessToken;
   } else {
-    return { message: "AccessToken이 없습니다" };
+    return;
   }
 };
 
@@ -32,6 +32,6 @@ export const getRefreshToken = async () => {
   if (session) {
     return session.user.item.token.refreshToken;
   } else {
-    return { message: "RefreshToken이 없습니다" };
+    return;
   }
 };


### PR DESCRIPTION
## 버그 내용

`getServerSession`과 `useClientSession`은 모두 `Next-Auth`에서 전달받은 유저 세션을 전달하는 함수와 커스텀훅이다. 기존에는 로그아웃이 된 상태면 `{message: 메세지 내용}` 형태의 값이 반환이 됐다. 이로인해 유저 세션을 가지고 조건부 처리를 하려고 하면, 값이 포함된 상태이기 때문에 처리가 안 되는 문제가 발생했다.

## 상세 내용

로그아웃 상태에서 유저 세션 혹은 토큰을 불러오려고 하면 함수를 종료시킴으로 `undefined`를 반환하도록 했다.

## 이슈 트래커

ref: #211, #212 