### PR TITLE
[🐛Bug] NextAuth 로그인 실패 에러 핸들링 로직 추가

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -25,18 +25,18 @@ export const authOptions = {
           }),
         });
 
-        const user = await res.json();
-
-        if (user) {
-          return user;
-        } else {
-          return null;
+        /* 로그인이 실패하면 에러처리 */
+        if (!res.ok) {
+          return;
         }
+
+        return await res.json();
       },
     }),
   ],
   pages: {
     signIn: "/signin",
+    error: "/signin",
   },
   callbacks: {
     async jwt({ token, user }) {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -98,7 +98,7 @@ export default function Header() {
           </button>
           <button
             aria-label="찜 목록 보기"
-            onClick={() => router.push("/mypage/wishlist")}
+            onClick={() => router.push("/mypage/mywishlist")}
             className="bg-center bg-no-repeat"
           >
             <Image


### PR DESCRIPTION
## 버그 설명

![image](https://github.com/likelion-lab15/essentia/assets/79128016/d35e3223-71cb-4fc2-8536-ab5723cacc06)

아이디, 비밀번호를 잘못 입력해도 로그인을 한 것처럼 인식이 되는 버그가 발견됐습니다.

![image](https://github.com/likelion-lab15/essentia/assets/79128016/7a5a473c-ddb2-4dec-b06f-cfe22c203019)

로그인에 실패했을 경우, 다음과 같은 객체가 반환이 됐는데 기존의 로직에서는 해당 객체 자체를 `user` 값이 들어왔다고 판단해 사용자로 하여금 로그인에 성공했다는 착각을 발생시켰습니다.

이와 같은 문제가 발생한 이유는 `fetch API`는 `axios`와 다르게 HTTP 에러를 자동으로 처리해주지 않기 때문에 별도로 에러 핸들링을 해줘야 했는데, 그러하지 않았기 때문입니다.

## 해결 방법

![image](https://github.com/likelion-lab15/essentia/assets/79128016/da8aae2b-55e9-4baf-8e86-1389a2818ddc)

`res.ok`는 실패할 경우 `0`을 반환하기 때문에, 조건문으로 `res.ok`의 값이 `false`일 경우 함수를 종료시켰습니다. 이럴 경우 NextAuth에서는 에러가 발생했다고 판단해 사용자를 NextAuth 에러 페이지로 이동시키는데 `pages` 옵션에서 에러 페이지를 `/signin` 라우트로 설정해줌으로 다시 로그인 페이지로 돌아가게 했습니다.

## 추가 코멘트

로그인에 성공했거나, 로그인에 실패했을 경우에 사용자로 하여금 그걸 알 수 있는 UI가 추가되는 게 좋아보입니다.